### PR TITLE
Update helper.py

### DIFF
--- a/custom_components/uponorX265/helper.py
+++ b/custom_components/uponorX265/helper.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
 
 
 def create_unique_id_from_user_input(user_input):
-    if CONF_UNIQUE_ID not in user_input and user_input[CONF_UNIQUE_ID] != "":
+    if CONF_UNIQUE_ID in user_input and user_input[CONF_UNIQUE_ID] != "":
         return user_input[CONF_UNIQUE_ID]
 
     return None


### PR DESCRIPTION
The error occurs in the helper function 'create_unique_id_from_user_input'. The logic is flawed, because if 'CONF_UNIQUE_ID' is not present in the 'user_input', it will still try to access this non-existent key.

### [helper.py](vscode-remote://dev-container/workspaces/core/config/custom_components/uponorX265/helper.py)

'''python
# ... existing code...

def create_unique_id_from_user_input(user_input):
if CONF_UNIQUE_ID in user_input and user_input[CONF_UNIQUE_ID] != "": return user_input[CONF_UNIQUE_ID]

return None

# ... existing code...
```

The condition was wrong. I changed 'not in' to 'in' and adjusted the logical link. Now we first check if the key exists, and only if it does, we try to access its value.