### PR TITLE
Add device_class to temperature sensor

### DIFF
--- a/custom_components/uponorx265/sensor.py
+++ b/custom_components/uponorx265/sensor.py
@@ -81,6 +81,7 @@ class UponorRoomCurrentTemperatureSensor(SensorEntity):
         self._thermostat = thermostat
         self._attr_name = f"{state_proxy.get_room_name(thermostat)} Current Temperature"
         self._attr_unique_id = f"{state_proxy.get_thermostat_id(thermostat)}_current_temp"
+        self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_state_class = SensorStateClass.MEASUREMENT
 


### PR DESCRIPTION
Added the attribute device_class to the current temperature sensor for better compatibility with some menus in HA