### PR TITLE
Convert waspVarValue values for SetAttributes action to strings, always

### DIFF
--- a/custom_components/uponorx265/jnap.py
+++ b/custom_components/uponorx265/jnap.py
@@ -26,7 +26,7 @@ class UponorJnap:
         payload = {
             "vars": list(map(lambda k: {
                 "waspVarName": k,
-                "waspVarValue": data[k],
+                "waspVarValue": str(data[k]),
             }, data.keys()))
         }
         r_json = self.post(headers={"x-jnap-action": "http://phyn.com/jnap/uponorsky/SetAttributes"}, payload=payload)


### PR DESCRIPTION
To maintain compatibility with R208 REST API (ref: https://github.com/dave-code-ruiz/uponorX265/issues/12)

