### PR TITLE
Stabilize HA outage behavior and migrate JNAP client to aiohttp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.log
+.vs/
+**/__pycache__/
+*.pyc

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 import math
 import logging
 
@@ -10,6 +11,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers import device_registry, entity_registry
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.util.dt as dt_util
 
 from .const import (
@@ -17,6 +19,7 @@ from .const import (
     SIGNAL_UPONOR_STATE_UPDATE,
     SCAN_INTERVAL,
     UNAVAILABLE_THRESHOLD,
+    RELOAD_COOLDOWN,
     STORAGE_KEY,
     STORAGE_VERSION,
     STATUS_OK,
@@ -61,13 +64,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             dev_reg.async_clear_config_entry(config_entry.entry_id)
             ent_reg.async_clear_config_entry(config_entry.entry_id)
             hass.config_entries.async_update_entry(config_entry, data=config_entry.options)
-    
+
     host = config_entry.data[CONF_HOST]
     unique_id = get_unique_id_from_config_entry(config_entry)
     store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+    session = async_get_clientsession(hass)
 
-    # Create the state proxy in the executor thread to avoid blocking the event loop
-    state_proxy = await hass.async_add_executor_job(lambda: UponorStateProxy(hass, host, store, unique_id, config_entry))
+    state_proxy = UponorStateProxy(hass, host, session, store, unique_id, config_entry)
     await state_proxy.async_update()
     thermostats = state_proxy.get_active_thermostats()
 
@@ -109,9 +112,9 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     return unload_ok
 
 class UponorStateProxy:
-    def __init__(self, hass, host, store, unique_id, config_entry):
+    def __init__(self, hass, host, session, store, unique_id, config_entry):
         self._hass = hass
-        self._client = UponorJnap(host)
+        self._client = UponorJnap(host, session)
         self._store = store
         self._data = {}
         self._storage_data = {}
@@ -120,6 +123,9 @@ class UponorStateProxy:
         self._config_entry = config_entry
         self._last_successful_update = None
         self._unavailable_since = None
+        self._update_lock = asyncio.Lock()
+        self._reload_in_progress = False
+        self._last_reload_attempt = None
 
     # Thermostats config
 
@@ -275,8 +281,8 @@ class UponorStateProxy:
         for thermostat in self._hass.data[self._unique_id]['thermostats']:
             if self.get_setpoint(thermostat) == self.get_min_limit(thermostat):
                 await self.async_set_setpoint(thermostat, self.get_max_limit(thermostat))
-        
-        await self._hass.async_add_executor_job(lambda: self._client.send_data({'sys_heat_cool_mode': '1'}))
+
+        await self._client.send_data({'sys_heat_cool_mode': '1'})
         self._data['sys_heat_cool_mode'] = '1'
         self._hass.async_create_task(self.call_state_update())
 
@@ -285,7 +291,7 @@ class UponorStateProxy:
             if self.get_setpoint(thermostat) == self.get_max_limit(thermostat):
                 await self.async_set_setpoint(thermostat, self.get_min_limit(thermostat))
 
-        await self._hass.async_add_executor_job(lambda: self._client.send_data({'sys_heat_cool_mode': '0'}))
+        await self._client.send_data({'sys_heat_cool_mode': '0'})
         self._data['sys_heat_cool_mode'] = '0'
         self._hass.async_create_task(self.call_state_update())
 
@@ -332,7 +338,7 @@ class UponorStateProxy:
     async def async_set_away(self, is_away):
         var = 'sys_forced_eco_mode'
         data = "1" if is_away else "0"
-        await self._hass.async_add_executor_job(lambda: self._client.send_data({var: data}))
+        await self._client.send_data({var: data})
         self._data[var] = data
         self._hass.async_create_task(self.call_state_update())
 
@@ -357,46 +363,52 @@ class UponorStateProxy:
 
     # Rest
     async def async_update(self,_=None):
-        try:
-            self.next_sp_from_dt = dt_util.now()
-            self._data = await self._hass.async_add_executor_job(lambda: self._client.get_data())
-            self._last_successful_update = dt_util.now()
-            self._unavailable_since = None
-            self._hass.async_create_task(self.call_state_update())
-        except Exception as ex:
-            _LOGGER.error("Uponor thermostat was unable to update: %s", ex)
-            if self._unavailable_since is None:
-                self._unavailable_since = dt_util.now()
-            elif dt_util.now() - self._unavailable_since > UNAVAILABLE_THRESHOLD:
-                _LOGGER.warning("Uponor entities have been unavailable for more than 2 minutes. Triggering reload...")
-                await self._hass.config_entries.async_reload(self._config_entry.entry_id)
+        if self._update_lock.locked():
+            _LOGGER.debug("Skipping Uponor update because a previous update is still running")
+            return
+
+        async with self._update_lock:
+            try:
+                self.next_sp_from_dt = dt_util.now()
+                self._data = await self._client.get_data()
+                self._last_successful_update = dt_util.now()
+                self._unavailable_since = None
+                self._hass.async_create_task(self.call_state_update())
                 return
-        
+            except Exception as ex:
+                _LOGGER.error("Uponor thermostat was unable to update: %s", ex)
+
+            now = dt_util.now()
+            if self._unavailable_since is None:
+                self._unavailable_since = now
+                return
+
+            if now - self._unavailable_since <= UNAVAILABLE_THRESHOLD:
+                return
+
+            if self._reload_in_progress:
+                return
+
+            if self._last_reload_attempt is not None and now - self._last_reload_attempt <= RELOAD_COOLDOWN:
+                return
+
+            self._reload_in_progress = True
+            self._last_reload_attempt = now
+            _LOGGER.warning("Uponor entities have been unavailable for more than 2 minutes. Triggering reload...")
+            try:
+                await self._hass.config_entries.async_reload(self._config_entry.entry_id)
+            finally:
+                self._reload_in_progress = False
+
     async def async_set_variable(self, var_name, var_value):
         _LOGGER.debug("Called set variable: name: %s, value: %s, data: %s", var_name, var_value, self._data)
-        await self._hass.async_add_executor_job(lambda: self._client.send_data({var_name: var_value}))
+        await self._client.send_data({var_name: var_value})
         self._data[var_name] = var_value
         self._hass.async_create_task(self.call_state_update())
 
     async def async_set_setpoint(self, thermostat, temp):
         var = thermostat + '_setpoint'
         setpoint = int(temp * 18 + self.get_active_setback(thermostat, temp) + 320)
-        await self._hass.async_add_executor_job(lambda: self._client.send_data({var: setpoint}))
+        await self._client.send_data({var: setpoint})
         self._data[var] = setpoint
         self._hass.async_create_task(self.call_state_update())
-    
-"""    async def async_set_setpoint(self, thermostat, temperature):
-        # Async wrapper for set_setpoint.
-        await self._hass.async_add_executor_job(self.set_setpoint, thermostat, temperature)
-        
-    def set_setpoint(self, thermostat, temp):
-        var = thermostat + '_setpoint'
-        setpoint = int(temp * 18 + self.get_active_setback(thermostat, temp) + 320)
-        self._client.send_data({var: setpoint})
-        self._data[var] = setpoint
-
-        # Ensure async update
-        if hasattr(self, "call_state_update"):  
-            self._hass.loop.call_soon_threadsafe(self._hass.async_create_task, self.call_state_update())
-        else:
-            _LOGGER.warning("call_state_update() method not found in UponorStateProxy") """

--- a/custom_components/uponorx265/const.py
+++ b/custom_components/uponorx265/const.py
@@ -7,6 +7,7 @@ DOMAIN = "uponorx265"
 SIGNAL_UPONOR_STATE_UPDATE = "uponor_state_update"
 SCAN_INTERVAL = timedelta(seconds=30)
 UNAVAILABLE_THRESHOLD = timedelta(minutes=2)
+RELOAD_COOLDOWN = timedelta(minutes=10)
 
 STORAGE_KEY = "uponorx265_data"
 STORAGE_VERSION = 1

--- a/custom_components/uponorx265/jnap.py
+++ b/custom_components/uponorx265/jnap.py
@@ -1,44 +1,65 @@
 # JNAP with network error retries
 
+import asyncio
 import json
-import requests
-from requests.adapters import HTTPAdapter, Retry
+import aiohttp
 
-REQUEST_RETRIES = 10 # retry attempts
-BACKOFF_FACTOR = 3 # exponential backoff
+REQUEST_RETRIES = 2
+RETRY_DELAY_SECONDS = 1
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=7, connect=2, sock_connect=2, sock_read=5)
 
 class UponorJnap:
-    def __init__(self, host):
+    def __init__(self, host, session: aiohttp.ClientSession):
         self.url = "http://" + host + "/JNAP/"
-        self.session = requests.Session()
-        self.session.mount('http://', HTTPAdapter(max_retries=Retry(
-            total=REQUEST_RETRIES,
-            connect=REQUEST_RETRIES,
-            read=REQUEST_RETRIES,
-            backoff_factor=BACKOFF_FACTOR,
-        )))
+        self.session = session
 
-    def get_data(self):
-        res = self.post(headers={"x-jnap-action": "http://phyn.com/jnap/uponorsky/GetAttributes"}, payload={})
-        return dict(map(lambda v: (v["waspVarName"], v["waspVarValue"]), res["output"]["vars"]))
+    async def get_data(self):
+        res = await self.post(headers={"x-jnap-action": "http://phyn.com/jnap/uponorsky/GetAttributes"}, payload={})
+        output = res.get("output")
+        if not isinstance(output, dict):
+            raise ValueError(f"Unexpected JNAP response: missing 'output'. keys={list(res.keys())}")
 
-    def send_data(self, data):
-        payload = {
-            "vars": list(map(lambda k: {
-                "waspVarName": k,
-                "waspVarValue": str(data[k]),
-            }, data.keys()))
+        vars_list = output.get("vars")
+        if not isinstance(vars_list, list):
+            raise ValueError("Unexpected JNAP response: 'output.vars' missing or invalid")
+
+        return {
+            item["waspVarName"]: item["waspVarValue"]
+            for item in vars_list
+            if isinstance(item, dict) and "waspVarName" in item and "waspVarValue" in item
         }
-        r_json = self.post(headers={"x-jnap-action": "http://phyn.com/jnap/uponorsky/SetAttributes"}, payload=payload)
-        if 'result' in r_json and not r_json['result'] == 'OK':
+
+    async def send_data(self, data):
+        payload = {
+            "vars": [
+                {
+                    "waspVarName": key,
+                    "waspVarValue": str(data[key]),
+                }
+                for key in data.keys()
+            ]
+        }
+
+        r_json = await self.post(headers={"x-jnap-action": "http://phyn.com/jnap/uponorsky/SetAttributes"}, payload=payload)
+        if r_json.get("result") != "OK":
             raise ValueError(r_json)
 
-    def post(self, headers, payload):
-      requests.packages.urllib3.disable_warnings()
-      try:
-          res = self.session.post(self.url, headers=headers, json=payload, verify=False)
-          if res.status_code != 200:
-              raise Exception("Status code: {}".format(res.status_code))
-          return res.json()
-      except Exception as e:
-          raise Exception("POST {} failed: {}".format(self.url, e))
+    async def post(self, headers, payload):
+        last_error = None
+        for attempt in range(REQUEST_RETRIES + 1):
+            try:
+                async with self.session.post(
+                    self.url,
+                    headers=headers,
+                    json=payload,
+                    ssl=False,
+                    timeout=REQUEST_TIMEOUT,
+                ) as response:
+                    response.raise_for_status()
+                    return await response.json()
+            except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as error:
+                last_error = error
+                if attempt < REQUEST_RETRIES:
+                    await asyncio.sleep(RETRY_DELAY_SECONDS)
+                    continue
+                raise Exception(f"POST {self.url} failed: {last_error}") from error


### PR DESCRIPTION
## What this PR does

This PR improves outage behavior for the `uponorx265` custom integration to prevent Home Assistant slowdowns when the Uponor controller is unreachable.

### Main changes

- Migrated controller HTTP calls from synchronous `requests` to async `aiohttp`
- Added explicit HTTP timeouts and bounded retry behavior
- Added defensive parsing for unexpected JNAP responses (`output.vars`)
- Added single-flight update protection (`asyncio.Lock`) to prevent overlapping polls
- Added reload throttling (`RELOAD_COOLDOWN`) to prevent config-entry reload storms
- Added `.gitignore` entries for local artifacts (`*.log`, `.vs/`, `__pycache__`, `*.pyc`)

## Why this is needed

When the controller is offline/unreachable, the integration could trigger repeated update failures, many parallel retries, and frequent reload attempts.  
That failure pattern can consume HA resources and make the instance unresponsive.

This PR makes failure handling graceful and rate-limited.

## Files changed

- `.gitignore`
- `custom_components/uponorx265/__init__.py`
- `custom_components/uponorx265/const.py`
- `custom_components/uponorx265/jnap.py`

## Validation

- Ran `python -m compileall custom_components/uponorx265` successfully.

## Expected behavior after this PR

- No overlapping update jobs during outages
- No rapid reload loops after unavailability threshold
- Faster failure return on network issues (due to explicit timeouts)
- Better HA stability when controller connectivity is lost