### PR TITLE
Bug fix: cancel previous logging on integration reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vs/
 **/__pycache__/
 *.pyc
+.github/
+.ignore_these/

--- a/README.fix.md
+++ b/README.fix.md
@@ -2,7 +2,7 @@
 
 This branch contains stability-focused changes compared to `main`.
 
-## Net changes vs main
+## Changes vs main
 
 - Migrated Uponor HTTP calls to async `aiohttp`
 - Added explicit timeouts and bounded retries
@@ -17,7 +17,7 @@ This branch contains stability-focused changes compared to `main`.
 To reduce Home Assistant resource spikes when the controller is unavailable,
 improve startup behavior with many thermostats, and make entities recover more reliably after temporary network/controller failures.
 
-## Additional net fixes vs main
+## Additional fixes vs `main`
 
 ### Bugs fixed
 - **`async_set_preset_mode` inverted logic** (`__init__.py`): AWAY/COMFORT calls to `async_set_away` were swapped — selecting Comfort enabled away mode and vice versa.

--- a/README.fix.md
+++ b/README.fix.md
@@ -20,6 +20,7 @@ improve startup behavior with many thermostats, and make entities recover more r
 ## Additional fixes vs `main`
 
 ### Bugs fixed
+- **`async_track_time_interval` cancel leak** (`__init__.py`): The cancel callable returned by `async_track_time_interval` was never stored or registered with `async_on_unload`. On each integration reload the old polling timer kept running alongside the new one, causing duplicate (and accumulating) error logging during controller outages. Present since upstream tag `1.0.1`. Fixed by capturing the cancel callable and passing it to `config_entry.async_on_unload`.
 - **`async_set_preset_mode` inverted logic** (`__init__.py`): AWAY/COMFORT calls to `async_set_away` were swapped — selecting Comfort enabled away mode and vice versa.
 - **ECO preset branch was dead code** (`climate.py`): The `async_set_preset_mode` ECO branch reassigned a local variable but never acted on it. Now correctly calls `async_set_preset_mode` with the computed target preset.
 - **`preset_mode` could return `PRESET_AWAY` not in `preset_modes`** (`climate.py`): Added `PRESET_AWAY` to the `preset_modes` list to match what `preset_mode` can return.

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -90,7 +90,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     # Track time interval for updates (use async function)
-    async_track_time_interval(hass, state_proxy.async_update, SCAN_INTERVAL)
+    cancel_interval = async_track_time_interval(hass, state_proxy.async_update, SCAN_INTERVAL)
+    config_entry.async_on_unload(cancel_interval)
 
     config_entry.async_on_unload(config_entry.add_update_listener(async_update_options))
 


### PR DESCRIPTION
One line bugfix. Whenever Uponor is offline for two minutes, restart is triggered, but old logging is never cancelled.

 **`async_track_time_interval` cancel leak** (`__init__.py`): The cancel callable returned by `async_track_time_interval` was never stored or registered with `async_on_unload`. On each integration reload the old polling timer kept running alongside the new one, causing duplicate (and accumulating) error logging during controller outages. Fixed by capturing the cancel callable and passing it to `config_entry.async_on_unload`.