### PR TITLE
New service for hardwaredump

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,53 @@ The language used is the **HA system language** (Settings → System → General
 not the individual user's profile language. Swedish (`sv`) and English (`en`) are supported;
 English is the fallback for all other languages.
 
-## Service
+## Services
 
-`uponorx265.set_variable` — sends a raw variable update to the Uponor API. Use with caution.
+### `uponorx265.set_variable`
+
+Sends a raw variable update to the Uponor API. Use with caution.
 
 | Field | Required | Description |
 |---|---|---|
 | `var_name` | Yes | Variable name, e.g. `sys_heat_cool_mode` |
 | `var_value` | Yes | Value to set |
 | `device_id` | No | Target gateway device. Required if more than one gateway is configured. |
+
+### `uponorx265.dump_hardware_info`
+
+Writes a JSON file to the HA config directory (`/config/uponorx265_hardware_<gateway_id>.json`)
+containing raw hardware IDs and capability flags for every thermostat and controller.
+Useful for identifying unrecognised device models and reporting them as issues.
+
+Example output:
+```json
+{
+  "gateway_id": "aabbccddeeff",
+  "controllers": [
+    {
+      "controller": "C1",
+      "name": "Floor 1",
+      "controller_id": "4195...",
+      "hardware_type_raw": "11",
+      "detected_model": "X-245"
+    }
+  ],
+  "thermostats": [
+    {
+      "thermostat": "C1_T1",
+      "name": "Living room",
+      "thermostat_id": "2691...",
+      "hardware_type_raw": "7",
+      "detected_model": "T-144",
+      "has_humidity_control": false,
+      "has_humidity_sensor": false,
+      "has_floor_temperature": true,
+      "is_public_device": false,
+      "is_sensor_only": false
+    }
+  ]
+}
+```
 
 ## Limitations
 
@@ -137,4 +175,4 @@ For the older Uponor X-165 module, see: https://github.com/dave-code-ruiz/uhomeu
 
 ## Feedback
 
-Issues and pull requests are welcome at https://github.com/fjonson95/uponorX265
+Your feedback, pull requests or any other contribution are welcome.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ the setpoint to the minimum (heating mode) or maximum (cooling mode) configured 
 | Away | Activates away/ECO mode for all thermostats |
 | Cooling mode | Switches the entire system between heating and cooling mode (only shown if cooling is available) |
 | HA controlled (per room) | Per-thermostat toggle for HA temperature control (mirrors the HA controlled preset) |
+| Included in average (per room) | Toggles whether the thermostat contributes to the controller's average room temperature (enabled in setup, default: off) |
 
 ### Sensors
 

--- a/README.md
+++ b/README.md
@@ -127,33 +127,31 @@ as a service response, shown directly in **Developer Tools → Services**.
 Useful for identifying unrecognised device models and reporting them as issues.
 
 Example output:
-```json
-{
-  "gateway_id": "aabbccddeeff",
-  "controllers": [
-    {
-      "controller": "C1",
-      "name": "Floor 1",
-      "controller_id": "4195...",
-      "hardware_type_raw": "11",
-      "detected_model": "X-245"
-    }
-  ],
-  "thermostats": [
-    {
-      "thermostat": "C1_T1",
-      "name": "Living room",
-      "thermostat_id": "2691...",
-      "hardware_type_raw": "7",
-      "detected_model": "T-144",
-      "has_humidity_control": false,
-      "has_humidity_sensor": false,
-      "has_floor_temperature": true,
-      "is_public_device": false,
-      "is_sensor_only": false
-    }
-  ]
-}
+```yaml
+gateways:
+  - gateway_id: "101683"
+    gateway_model: R-208
+    controllers:
+      - controller: C1
+        sn_start: "4195"
+        hardware_type_raw: "0"
+        detected_model: X-245
+        sw_version: "1.22"
+      - controller: C2
+        sn_start: "4195"
+        hardware_type_raw: "0"
+        detected_model: X-245
+        sw_version: "1.22"
+    thermostats:
+      - thermostat: C1_T1
+        sn_start: "2692"
+        hardware_type_raw: "0"
+        detected_model: T-145
+        has_humidity_control: 0
+        has_humidity_sensor: false
+        has_floor_temperature: false
+        is_public_device: 0
+        is_sensor_only: 0
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Sends a raw variable update to the Uponor API. Use with caution.
 
 ### `uponorx265.dump_hardware_info`
 
-Writes a JSON file to the HA config directory (`/config/uponorx265_hardware_<gateway_id>.json`)
-containing raw hardware IDs and capability flags for every thermostat and controller.
+Returns raw hardware IDs and capability flags for every thermostat and controller
+as a service response, shown directly in **Developer Tools → Services**.
 Useful for identifying unrecognised device models and reporting them as issues.
 
 Example output:

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -1,6 +1,8 @@
 import asyncio
+import json
 import math
 import logging
+import os
 
 import voluptuous as vol
 
@@ -187,6 +189,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             DOMAIN, "set_variable", _create_set_variable_handler(hass), schema=SET_VARIABLE_SCHEMA
         )
 
+    if not hass.services.has_service(DOMAIN, "dump_hardware_info"):
+        hass.services.async_register(
+            DOMAIN, "dump_hardware_info", _create_dump_hardware_handler(hass)
+        )
+
     # Migrate entity unique_ids from pre-1.1.2 bare format to prefixed format.
     # Must run before platform setup so HA matches existing registry entries
     # to the new unique_ids instead of creating duplicate entities.
@@ -245,6 +252,76 @@ def _create_set_variable_handler(hass: HomeAssistant):
             await proxy.async_set_variable(var_name, var_value)
 
     return handle_set_variable
+
+
+def _create_dump_hardware_handler(hass: HomeAssistant):
+    """Build the uponorx265.dump_hardware_info service handler.
+
+    Writes a JSON file to <config>/uponorx265_hardware_<gateway_id>.json for each
+    configured gateway, containing raw hardware IDs and capability flags for every
+    thermostat and controller. Useful for identifying unknown device models.
+    """
+    async def handle_dump_hardware_info(call) -> None:
+        all_proxies = _get_all_state_proxies(hass)
+        if not all_proxies:
+            _LOGGER.warning("dump_hardware_info: no gateways loaded")
+            return
+
+        for unique_id, proxy in all_proxies.items():
+            output = {
+                "gateway_id": proxy.get_gateway_id(),
+                "gateway_model": proxy.get_model(),
+                "controllers": [],
+                "thermostats": [],
+            }
+
+            for entry in hass.config_entries.async_entries(DOMAIN):
+                if entry.unique_id != unique_id:
+                    continue
+                thermostats = hass.data.get(unique_id, {}).get("thermostats", [])
+
+                seen_controllers = set()
+                for thermostat in thermostats:
+                    controller = thermostat.split('_')[0]
+                    if controller not in seen_controllers:
+                        seen_controllers.add(controller)
+                        ctrl_var = controller + '_hardware_type'
+                        ctrl_hwid = proxy._data.get(ctrl_var)
+                        ctrl_id = proxy.get_controller_id(controller)
+                        output["controllers"].append({
+                            "controller": controller,
+                            "name": proxy.get_controller_name(controller),
+                            "controller_id": ctrl_id,
+                            "sn_start": ctrl_id[:4] if ctrl_id else None,
+                            "hardware_type_raw": ctrl_hwid,
+                            "detected_model": proxy.get_controller_hardware(controller),
+                            "sw_version": proxy.get_controller_version(controller),
+                        })
+
+                    t_var = thermostat + '_thermostat_type'
+                    t_hwid = proxy._data.get(t_var)
+                    t_id = proxy.get_thermostat_id(thermostat)
+                    output["thermostats"].append({
+                        "thermostat": thermostat,
+                        "name": proxy.get_room_name(thermostat),
+                        "thermostat_id": t_id,
+                        "sn_start": t_id[:4] if t_id else None,
+                        "hardware_type_raw": t_hwid,
+                        "detected_model": proxy.get_thermostat_model(thermostat),
+                        "has_humidity_control": proxy.has_humidity_control(thermostat),
+                        "has_humidity_sensor": proxy.has_humidity_sensor(thermostat),
+                        "has_floor_temperature": proxy.has_floor_temperature(thermostat),
+                        "is_public_device": proxy.is_public_device(thermostat),
+                        "is_sensor_only": proxy.is_sensor_only(thermostat),
+                    })
+
+            filename = f"uponorx265_hardware_{proxy.get_gateway_id()}.json"
+            filepath = hass.config.path(filename)
+            with open(filepath, "w", encoding="utf-8") as f:
+                json.dump(output, f, indent=2, default=str)
+            _LOGGER.info("dump_hardware_info: wrote %s", filepath)
+
+    return handle_dump_hardware_info
 
 
 class UponorStateProxy:

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -441,6 +441,17 @@ class UponorStateProxy:
                 return round((temp - 320) / 18, 1)
         return None
 
+    def get_inavg(self, thermostat):
+        var = thermostat.replace('_T', '_channel_') + '_ave_temp'
+        return self._data.get(var) == "1"
+        
+    async def async_iset_inavg(self, thermostat, override):
+        var = thermostat.replace('_T', '_channel_') + '_ave_temp'
+        data = "1" if override else "0"
+        await self._client.send_data({var: data})
+        self._data[var] = data
+        self._hass.async_create_task(self.call_state_update())        
+
     def _get_room_name_from_data(self, thermostat):
         var = 'cust_' + thermostat + '_name'
         return self._data.get(var)

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -1,12 +1,10 @@
 import asyncio
-import json
 import math
 import logging
-import os
 
 import voluptuous as vol
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 
@@ -191,7 +189,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     if not hass.services.has_service(DOMAIN, "dump_hardware_info"):
         hass.services.async_register(
-            DOMAIN, "dump_hardware_info", _create_dump_hardware_handler(hass)
+            DOMAIN, "dump_hardware_info", _create_dump_hardware_handler(hass),
+            supports_response=SupportsResponse.ONLY,
         )
 
     # Migrate entity unique_ids from pre-1.1.2 bare format to prefixed format.
@@ -257,69 +256,60 @@ def _create_set_variable_handler(hass: HomeAssistant):
 def _create_dump_hardware_handler(hass: HomeAssistant):
     """Build the uponorx265.dump_hardware_info service handler.
 
-    Writes a JSON file to <config>/uponorx265_hardware_<gateway_id>.json for each
-    configured gateway, containing raw hardware IDs and capability flags for every
-    thermostat and controller. Useful for identifying unknown device models.
+    Returns hardware IDs and capability flags for every thermostat and
+    controller as a service response, visible directly in Developer Tools.
     """
-    async def handle_dump_hardware_info(call) -> None:
+    async def handle_dump_hardware_info(call) -> dict:
         all_proxies = _get_all_state_proxies(hass)
         if not all_proxies:
             _LOGGER.warning("dump_hardware_info: no gateways loaded")
-            return
+            return {}
+
+        result = {"gateways": []}
 
         for unique_id, proxy in all_proxies.items():
-            output = {
+            gateway = {
                 "gateway_id": proxy.get_gateway_id(),
                 "gateway_model": proxy.get_model(),
                 "controllers": [],
                 "thermostats": [],
             }
 
-            for entry in hass.config_entries.async_entries(DOMAIN):
-                if entry.unique_id != unique_id:
-                    continue
-                thermostats = hass.data.get(unique_id, {}).get("thermostats", [])
-
-                seen_controllers = set()
-                for thermostat in thermostats:
-                    controller = thermostat.split('_')[0]
-                    if controller not in seen_controllers:
-                        seen_controllers.add(controller)
-                        ctrl_var = controller + '_hardware_type'
-                        ctrl_hwid = proxy._data.get(ctrl_var)
-                        ctrl_id = proxy.get_controller_id(controller)
-                        output["controllers"].append({
-                            "controller": controller,
-                            "name": proxy.get_controller_name(controller),
-                            "controller_id": ctrl_id,
-                            "sn_start": ctrl_id[:4] if ctrl_id else None,
-                            "hardware_type_raw": ctrl_hwid,
-                            "detected_model": proxy.get_controller_hardware(controller),
-                            "sw_version": proxy.get_controller_version(controller),
-                        })
-
-                    t_var = thermostat + '_thermostat_type'
-                    t_hwid = proxy._data.get(t_var)
-                    t_id = proxy.get_thermostat_id(thermostat)
-                    output["thermostats"].append({
-                        "thermostat": thermostat,
-                        "name": proxy.get_room_name(thermostat),
-                        "thermostat_id": t_id,
-                        "sn_start": t_id[:4] if t_id else None,
-                        "hardware_type_raw": t_hwid,
-                        "detected_model": proxy.get_thermostat_model(thermostat),
-                        "has_humidity_control": proxy.has_humidity_control(thermostat),
-                        "has_humidity_sensor": proxy.has_humidity_sensor(thermostat),
-                        "has_floor_temperature": proxy.has_floor_temperature(thermostat),
-                        "is_public_device": proxy.is_public_device(thermostat),
-                        "is_sensor_only": proxy.is_sensor_only(thermostat),
+            thermostats = hass.data.get(unique_id, {}).get("thermostats", [])
+            seen_controllers = set()
+            for thermostat in thermostats:
+                controller = thermostat.split('_')[0]
+                if controller not in seen_controllers:
+                    seen_controllers.add(controller)
+                    ctrl_id = proxy.get_controller_id(controller)
+                    gateway["controllers"].append({
+                        "controller": controller,
+                        "name": proxy.get_controller_name(controller),
+                        "controller_id": ctrl_id,
+                        "sn_start": ctrl_id[:4] if ctrl_id else None,
+                        "hardware_type_raw": proxy._data.get(controller + '_hardware_type'),
+                        "detected_model": str(proxy.get_controller_hardware(controller)),
+                        "sw_version": proxy.get_controller_version(controller),
                     })
 
-            filename = f"uponorx265_hardware_{proxy.get_gateway_id()}.json"
-            filepath = hass.config.path(filename)
-            with open(filepath, "w", encoding="utf-8") as f:
-                json.dump(output, f, indent=2, default=str)
-            _LOGGER.info("dump_hardware_info: wrote %s", filepath)
+                t_id = proxy.get_thermostat_id(thermostat)
+                gateway["thermostats"].append({
+                    "thermostat": thermostat,
+                    "name": proxy.get_room_name(thermostat),
+                    "thermostat_id": t_id,
+                    "sn_start": t_id[:4] if t_id else None,
+                    "hardware_type_raw": proxy._data.get(thermostat + '_thermostat_type'),
+                    "detected_model": str(proxy.get_thermostat_model(thermostat)),
+                    "has_humidity_control": proxy.has_humidity_control(thermostat),
+                    "has_humidity_sensor": proxy.has_humidity_sensor(thermostat),
+                    "has_floor_temperature": proxy.has_floor_temperature(thermostat),
+                    "is_public_device": proxy.is_public_device(thermostat),
+                    "is_sensor_only": proxy.is_sensor_only(thermostat),
+                })
+
+            result["gateways"].append(gateway)
+
+        return result
 
     return handle_dump_hardware_info
 

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -284,8 +284,6 @@ def _create_dump_hardware_handler(hass: HomeAssistant):
                     ctrl_id = proxy.get_controller_id(controller)
                     gateway["controllers"].append({
                         "controller": controller,
-                        "name": proxy.get_controller_name(controller),
-                        "controller_id": ctrl_id,
                         "sn_start": ctrl_id[:4] if ctrl_id else None,
                         "hardware_type_raw": proxy._data.get(controller + '_hardware_type'),
                         "detected_model": str(proxy.get_controller_hardware(controller)),
@@ -295,8 +293,6 @@ def _create_dump_hardware_handler(hass: HomeAssistant):
                 t_id = proxy.get_thermostat_id(thermostat)
                 gateway["thermostats"].append({
                     "thermostat": thermostat,
-                    "name": proxy.get_room_name(thermostat),
-                    "thermostat_id": t_id,
                     "sn_start": t_id[:4] if t_id else None,
                     "hardware_type_raw": proxy._data.get(thermostat + '_thermostat_type'),
                     "detected_model": str(proxy.get_thermostat_model(thermostat)),

--- a/custom_components/uponorx265/config_flow.py
+++ b/custom_components/uponorx265/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_CREATE_CONTROLLERS,
     CONF_SENSOR_TEMP,
     CONF_BINARY_SENSOR_VALVE,
+    CONF_SWITCH_SENSOR_AVG,
 )
 
 from .helper import (
@@ -123,6 +124,10 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(
                 CONF_BINARY_SENSOR_VALVE,
                 default=current_data.get(CONF_BINARY_SENSOR_VALVE, False),
+            ): bool,
+            vol.Required(
+                CONF_SWITCH_SENSOR_AVG,
+                default=current_data.get(CONF_SWITCH_SENSOR_AVG, False),
             ): bool,
         })
 
@@ -229,5 +234,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required(
                 CONF_BINARY_SENSOR_VALVE,
                 default=current_data.get(CONF_BINARY_SENSOR_VALVE, False),
+            ): bool,
+            vol.Required(
+                CONF_SWITCH_SENSOR_AVG,
+                default=current_data.get(CONF_SWITCH_SENSOR_AVG, False),
             ): bool,
         })

--- a/custom_components/uponorx265/const.py
+++ b/custom_components/uponorx265/const.py
@@ -34,5 +34,6 @@ PRESET_MANUAL = 'ha_controlled'
 CONF_CREATE_CONTROLLERS = "create_controllers"
 CONF_SENSOR_TEMP = "sensor_temperature"
 CONF_BINARY_SENSOR_VALVE = "binary_sensor_valve"
+CONF_SWITCH_SENSOR_AVG = "switch_sensor_avg"
 TOO_HIGH_TEMP_LIMIT = 4508
 DEFAULT_TEMP = 20

--- a/custom_components/uponorx265/strings.json
+++ b/custom_components/uponorx265/strings.json
@@ -233,6 +233,10 @@
           "example": "0"
         }
       }
+    },
+    "dump_hardware_info": {
+      "name": "Dump Hardware Info",
+      "description": "Writes a JSON file to the HA config directory with raw hardware IDs and capability flags for every thermostat and controller. Useful for identifying unknown device models. File: uponorx265_hardware_<gateway_id>.json"
     }
   }
 }

--- a/custom_components/uponorx265/strings.json
+++ b/custom_components/uponorx265/strings.json
@@ -236,7 +236,7 @@
     },
     "dump_hardware_info": {
       "name": "Dump Hardware Info",
-      "description": "Writes a JSON file to the HA config directory with raw hardware IDs and capability flags for every thermostat and controller. Useful for identifying unknown device models. File: uponorx265_hardware_<gateway_id>.json"
+      "description": "Returns raw hardware IDs and capability flags for every thermostat and controller. The response is shown directly in Developer Tools → Services. Useful for identifying unknown device models."
     }
   }
 }

--- a/custom_components/uponorx265/strings.json
+++ b/custom_components/uponorx265/strings.json
@@ -26,7 +26,8 @@
         "description": "Choose which optional sensors to create per thermostat",
         "data": {
           "sensor_temperature": "Create room temperature sensor",
-          "binary_sensor_valve": "Create valve binary sensor"
+          "binary_sensor_valve": "Create valve binary sensor",
+          "switch_sensor_avg": "Create average inclusion switch"
         }
       },
       "rooms": {
@@ -106,7 +107,8 @@
         "description": "Choose which optional sensors to create per thermostat",
         "data": {
           "sensor_temperature": "Create room temperature sensor",
-          "binary_sensor_valve": "Create valve binary sensor"
+          "binary_sensor_valve": "Create valve binary sensor",
+          "switch_sensor_avg": "Create average inclusion switch"
         }
       }
     }
@@ -209,6 +211,9 @@
       },
       "local_override": {
         "name": "HA controlled"
+      },
+      "avg_included": {
+        "name": "Included in average"
       }
     },
     "binary_sensor": {

--- a/custom_components/uponorx265/switch.py
+++ b/custom_components/uponorx265/switch.py
@@ -2,7 +2,7 @@ import logging
 
 from homeassistant.components.switch import SwitchEntity
 
-from .const import PRESET_MANUAL
+from .const import PRESET_MANUAL, CONF_SWITCH_SENSOR_AVG
 from .helper import (
     get_unique_id_from_config_entry,
     UponorGatewayEntity,
@@ -23,6 +23,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     for thermostat in hass.data[unique_id]["thermostats"]:
         entities.append(LocalOverride(unique_id, state_proxy, thermostat))
+        
+        if entry.data.get(CONF_SWITCH_SENSOR_AVG, False):
+            entities.append(ClimatControlInAvg(unique_id, state_proxy, thermostat))
 
     async_add_entities(entities)
 
@@ -87,3 +90,23 @@ class LocalOverride(UponorThermostatEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs):
         await self._state_proxy.async_local_override(self._thermostat, False)
         self.async_write_ha_state()
+
+class ClimatControlInAvg(UponorThermostatEntity, SwitchEntity):
+    _attr_translation_key = "avg_included"
+    
+    def __init__(self, unique_instance_id, state_proxy, thermostat):
+        super().__init__(unique_instance_id, state_proxy, thermostat)
+        self._attr_unique_id = f"{unique_instance_id}_{state_proxy.get_thermostat_id(thermostat)}_avg_included"
+        self._attr_icon = "mdi:thermometer-check"
+        
+    @property
+    def is_on(self):
+        return self._state_proxy.get_inavg(self._thermostat)
+
+    async def async_turn_on(self, **kwargs):
+        await self._state_proxy.async_iset_inavg(self._thermostat, True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        await self._state_proxy.async_iset_inavg(self._thermostat, False)
+        self.async_write_ha_state()    

--- a/custom_components/uponorx265/translations/en.json
+++ b/custom_components/uponorx265/translations/en.json
@@ -218,6 +218,10 @@
     }
   },
   "services": {
+    "dump_hardware_info": {
+      "name": "Dump Hardware Info",
+      "description": "Writes a JSON file to the HA config directory with raw hardware IDs and capability flags for every thermostat and controller. Useful for identifying unknown device models. File: uponorx265_hardware_<gateway_id>.json"
+    },
     "set_variable": {
       "name": "Set Variable",
       "description": "Send a variable update to the Uponor API",

--- a/custom_components/uponorx265/translations/en.json
+++ b/custom_components/uponorx265/translations/en.json
@@ -26,7 +26,8 @@
         "description": "Choose which optional sensors to create per thermostat",
         "data": {
           "sensor_temperature": "Create room temperature sensor",
-          "binary_sensor_valve": "Create valve binary sensor"
+          "binary_sensor_valve": "Create valve binary sensor",
+          "switch_sensor_avg": "Create average inclusion switch"
         }
       },
       "rooms": {
@@ -106,7 +107,8 @@
         "description": "Choose which optional sensors to create per thermostat",
         "data": {
           "sensor_temperature": "Create room temperature sensor",
-          "binary_sensor_valve": "Create valve binary sensor"
+          "binary_sensor_valve": "Create valve binary sensor",
+          "switch_sensor_avg": "Create average inclusion switch"
         }
       }
     }
@@ -209,6 +211,9 @@
       },
       "local_override": {
         "name": "HA controlled"
+      },
+      "avg_included": {
+        "name": "Included in average"
       }
     },
     "binary_sensor": {

--- a/custom_components/uponorx265/translations/en.json
+++ b/custom_components/uponorx265/translations/en.json
@@ -220,7 +220,7 @@
   "services": {
     "dump_hardware_info": {
       "name": "Dump Hardware Info",
-      "description": "Writes a JSON file to the HA config directory with raw hardware IDs and capability flags for every thermostat and controller. Useful for identifying unknown device models. File: uponorx265_hardware_<gateway_id>.json"
+      "description": "Returns raw hardware IDs and capability flags for every thermostat and controller. The response is shown directly in Developer Tools → Services. Useful for identifying unknown device models."
     },
     "set_variable": {
       "name": "Set Variable",

--- a/custom_components/uponorx265/translations/sv.json
+++ b/custom_components/uponorx265/translations/sv.json
@@ -218,6 +218,10 @@
     }
   },
   "services": {
+    "dump_hardware_info": {
+      "name": "Dumpa hårdvaruinfo",
+      "description": "Skriver en JSON-fil till HA:s config-mapp med råa hårdvaru-ID:n och kapabilitetsflaggor för alla termostater och styrenheter. Användbar för att identifiera okända enhetsmodeller. Fil: uponorx265_hardware_<gateway_id>.json"
+    },
     "set_variable": {
       "name": "Sätt variabel",
       "description": "Skicka en variabeluppdatering till Uponor API",

--- a/custom_components/uponorx265/translations/sv.json
+++ b/custom_components/uponorx265/translations/sv.json
@@ -26,7 +26,8 @@
         "description": "Välj vilka valfria sensorer som ska skapas per termostat",
         "data": {
           "sensor_temperature": "Skapa rumstemperatursensor",
-          "binary_sensor_valve": "Skapa ventil-binärsensor"
+          "binary_sensor_valve": "Skapa ventil-binärsensor",
+          "switch_sensor_avg": "Skapa switch för medelvärdesinkludering"
         }
       },
       "rooms": {
@@ -106,7 +107,8 @@
         "description": "Välj vilka valfria sensorer som ska skapas per termostat",
         "data": {
           "sensor_temperature": "Skapa rumstemperatursensor",
-          "binary_sensor_valve": "Skapa ventil-binärsensor"
+          "binary_sensor_valve": "Skapa ventil-binärsensor",
+          "switch_sensor_avg": "Skapa binärsensor för medelvärdesinkludering"
         }
       }
     }
@@ -209,6 +211,9 @@
       },
       "local_override": {
         "name": "HA-styrd"
+      },
+      "avg_included": {
+        "name": "Ingår i medelvärde"
       }
     },
     "binary_sensor": {

--- a/custom_components/uponorx265/translations/sv.json
+++ b/custom_components/uponorx265/translations/sv.json
@@ -220,7 +220,7 @@
   "services": {
     "dump_hardware_info": {
       "name": "Dumpa hårdvaruinfo",
-      "description": "Skriver en JSON-fil till HA:s config-mapp med råa hårdvaru-ID:n och kapabilitetsflaggor för alla termostater och styrenheter. Användbar för att identifiera okända enhetsmodeller. Fil: uponorx265_hardware_<gateway_id>.json"
+      "description": "Returnerar råa hårdvaru-ID:n och kapabilitetsflaggor för alla termostater och styrenheter. Svaret visas direkt i Utvecklarverktyg → Tjänster. Användbar för att identifiera okända enhetsmodeller."
     },
     "set_variable": {
       "name": "Sätt variabel",


### PR DESCRIPTION
Added a switch to include the thermostat in the controller's average.
Added a new service to dump information about thermostats and controllers in order to finalize model identification.