### PR TITLE
Fix 1.1.5-1.1.7 upgrade regressions

### DIFF
--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -390,7 +390,7 @@ class UponorStateProxy:
             hwid = int(self._data[var])
             controller_id = self.get_controller_id(controller)
             if controller_id is None:
-                return hwid
+                return None
             sn = controller_id[:4]
             prodk = sn[:3]
             mod = sn[-1:]
@@ -404,7 +404,9 @@ class UponorStateProxy:
 # Smatrix Base PRO
 #                   return("X-147")
 # Modbus RTU model  return("X-147")
-            return hwid
+            # The raw hardware type is a device class, not a model id -
+            # report no model rather than a misleading number.
+            return None
 
     def get_controller_name(self, controller):
         configured_name = self._config_entry.data.get(controller.lower())
@@ -664,7 +666,9 @@ class UponorStateProxy:
 #                   return("T-168") #Digital display/External temp/RH/TimeDate
 #                   return("T-169") #Digital display/External temp/RH
 #                    return("T-247")
-        return hwid
+        # The raw hardware type is a device class, not a model id -
+        # report no model rather than a misleading number.
+        return None
 
     def get_model(self):
         return "R-208"

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -180,10 +180,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     thermostats = state_proxy.get_cached_thermostats()
     if thermostats:
-        if config_entry.entry_id:
-            await state_proxy.async_update()
-        else:
-            hass.async_create_task(state_proxy.async_update())
+        hass.async_create_task(state_proxy.async_update())
     else:
         await state_proxy.async_update()
         thermostats = state_proxy.get_active_thermostats()

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -52,7 +52,8 @@ from .helper import get_unique_id_from_config_entry, _get_mac_with_arp_refresh
 
 from homeassistant.components.climate.const import (
     PRESET_AWAY,
-    PRESET_COMFORT
+    PRESET_COMFORT,
+    PRESET_ECO
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -844,7 +845,7 @@ class UponorStateProxy:
         await self.async_set_setpoint(thermostat, off_temp)
 
     async def async_set_preset_mode(self, preset_mode):
-        if preset_mode == PRESET_AWAY:
+        if preset_mode in (PRESET_AWAY, PRESET_ECO):
             await self.async_set_away(True)
         elif preset_mode == PRESET_COMFORT:
             await self.async_set_away(False)

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -111,19 +111,30 @@ def _resolve_target_proxies(hass: HomeAssistant, call) -> list:
 
 
 def _migrate_entity_unique_ids(hass: HomeAssistant, config_entry: ConfigEntry, unique_instance_id: str) -> None:
-    
+    """Migrate entity registry entries to the current unique_id formats.
+
+    Two historical format changes are handled, composing so that an upgrade
+    from any older version lands on the current format in one pass:
+    - pre-1.1.2: bare ids (no config-entry prefix) gain the prefix
+    - pre-1.1.5: climate ids (no '_climate' suffix) gain the suffix
+    """
     ent_reg = entity_registry.async_get(hass)
     entries = entity_registry.async_entries_for_config_entry(ent_reg, config_entry.entry_id)
     prefix = f"{unique_instance_id}_"
 
     for entry in entries:
-        if entry.unique_id.startswith(prefix):
+        new_unique_id = entry.unique_id
+        if not new_unique_id.startswith(prefix):
+            new_unique_id = f"{prefix}{new_unique_id}"
+        if entry.domain == "climate" and not new_unique_id.endswith("_climate"):
+            new_unique_id = f"{new_unique_id}_climate"
+
+        if new_unique_id == entry.unique_id:
             continue
 
-        new_unique_id = f"{prefix}{entry.unique_id}"
-
-        # Scenario 2: prefixed entity already exists (created by 1.1.2 as '_2').
-        # Remove the stale bare-id entry instead of failing.
+        # Scenario 2: an entity with the new unique_id already exists (created
+        # as a duplicate by a version that lacked this migration). Remove the
+        # stale old-id entry instead of failing.
         existing_entity_id = ent_reg.async_get_entity_id(entry.domain, DOMAIN, new_unique_id)
         if existing_entity_id is not None:
             _LOGGER.info(
@@ -193,7 +204,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             supports_response=SupportsResponse.ONLY,
         )
 
-    # Migrate entity unique_ids from pre-1.1.2 bare format to prefixed format.
+    # Migrate entity unique_ids from older formats (pre-1.1.2 bare ids,
+    # pre-1.1.5 climate ids without '_climate' suffix).
     # Must run before platform setup so HA matches existing registry entries
     # to the new unique_ids instead of creating duplicate entities.
     _migrate_entity_unique_ids(hass, config_entry, unique_id)

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -746,13 +746,15 @@ class UponorStateProxy:
         if var_cool_setback in self._data and self.is_cool_enabled():
             cool_setback = int(self._data[var_cool_setback]) * -1
 
-        eco_setback = 0
-        var_eco_setback = thermostat + '_eco_offset'
-        mode = -1 if self.is_cool_enabled() else 1
-        if var_eco_setback in self._data and (self.is_eco(thermostat) or self.is_away()):
-            eco_setback = int(self._data[var_eco_setback]) * mode
+        return cool_setback + self._get_active_eco_setback(thermostat)
 
-        return cool_setback + eco_setback
+    def _get_active_eco_setback(self, thermostat):
+        var = thermostat + '_eco_offset'
+        if var not in self._data or not self.is_setback_active(thermostat):
+            return 0
+
+        mode = -1 if self.is_cool_enabled() else 1
+        return int(self._data[var]) * mode
 
     def get_local_override(self, thermostat):
         var = thermostat + '_pub_setpoint_override'
@@ -889,6 +891,9 @@ class UponorStateProxy:
         return (var in self._data and self._data[var] == "1") or (
                     var_temp in self._data and self._data[var_temp] == "1")
 
+    def is_setback_active(self, thermostat):
+        return self.is_away() or self.is_eco(thermostat)
+
     def get_eco_setback(self, thermostat):
         var = thermostat + '_eco_offset'
         if var in self._data:
@@ -948,6 +953,37 @@ class UponorStateProxy:
         _LOGGER.debug("Called set variable: name: %s, value: %s", var_name, var_value)
         await self._client.send_data({var_name: var_value})
         self._data[var_name] = var_value
+        self._hass.async_create_task(self.call_state_update())
+
+    async def async_set_target_temperature(self, thermostat, temp):
+        if self.is_setback_active(thermostat):
+            await self.async_set_setback_target(thermostat, temp)
+            return
+
+        await self.async_set_setpoint(thermostat, temp)
+
+    async def async_set_setback_target(self, thermostat, temp):
+        current_target = self.get_setpoint(thermostat)
+        if current_target is None:
+            await self.async_set_setpoint(thermostat, temp)
+            return
+
+        active_eco_setback = self._get_active_eco_setback(thermostat)
+        comfort_target = current_target + active_eco_setback / 18
+        mode = -1 if self.is_cool_enabled() else 1
+        offset = round((comfort_target - temp) * 18 / mode)
+
+        if offset < 0:
+            _LOGGER.warning(
+                "Requested setback target %.1f for %s would require a negative eco offset; using 0 instead",
+                temp,
+                thermostat,
+            )
+            offset = 0
+
+        var = thermostat + '_eco_offset'
+        await self._client.send_data({var: offset})
+        self._data[var] = offset
         self._hass.async_create_task(self.call_state_update())
 
     async def async_set_setpoint(self, thermostat, temp):

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -158,6 +158,23 @@ def _migrate_entity_unique_ids(hass: HomeAssistant, config_entry: ConfigEntry, u
                 entry.entity_id, entry.unique_id, exc,
             )
 
+def _remove_unsupported_local_override_entities(hass: HomeAssistant, config_entry: ConfigEntry, unique_instance_id: str, state_proxy, thermostats) -> None:
+    """Remove local-override switches created for thermostats that do not support the feature."""
+    ent_reg = entity_registry.async_get(hass)
+    stale_unique_ids = {
+        f"{unique_instance_id}_{state_proxy.get_thermostat_id(thermostat)}_local_override"
+        for thermostat in thermostats
+        if not state_proxy.requires_local_override(thermostat)
+    }
+    for entry in entity_registry.async_entries_for_config_entry(ent_reg, config_entry.entry_id):
+        if entry.domain == "switch" and entry.unique_id in stale_unique_ids:
+            _LOGGER.info(
+                "Removing switch %s: thermostat does not support local override",
+                entry.entity_id,
+            )
+            ent_reg.async_remove(entry.entity_id)
+
+
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     # Sync options to data if they differ
     if config_entry.options:
@@ -338,6 +355,7 @@ class UponorStateProxy:
         self._reload_in_progress = False
         self._last_reload_attempt = None
         self._gateway_id = None
+        self._stale_override_switches_cleaned = False
         _LOGGER.debug(f"Configdata = {self._config_entry}")
     # Controlers config  
     def get_active_controllers(self):
@@ -756,6 +774,14 @@ class UponorStateProxy:
         mode = -1 if self.is_cool_enabled() else 1
         return int(self._data[var]) * mode
 
+    def requires_local_override(self, thermostat):
+        # T-144/T-145 dial thermostats accept remote setpoint changes only
+        # while local override is enabled. Detection mirrors
+        # get_thermostat_model but works from the cached thermostat id, so it
+        # is usable before the first live update.
+        sn = str(self.get_thermostat_id(thermostat))[:4]
+        return sn[:3] == "269" and sn[3:4] in ("1", "2")
+
     def get_local_override(self, thermostat):
         var = thermostat + '_pub_setpoint_override'
         return var in self._data and int(self._data[var]) != 0
@@ -921,6 +947,16 @@ class UponorStateProxy:
                 self._last_successful_update = dt_util.now()
                 self._unavailable_since = None
                 await self._async_persist_discovery_metadata()
+
+                # Runs here rather than at setup because model detection is
+                # only authoritative with live data; on a cache-based startup
+                # it would treat dial thermostats as unsupported.
+                if not self._stale_override_switches_cleaned:
+                    self._stale_override_switches_cleaned = True
+                    _remove_unsupported_local_override_entities(
+                        self._hass, self._config_entry, self._unique_id,
+                        self, self.get_active_thermostats(),
+                    )
 
                 self._hass.async_create_task(self.call_state_update())
                 return

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -403,7 +403,7 @@ class UponorStateProxy:
 #                   return("X-265")
 # Smatrix Base PRO
 #                   return("X-147")
-# Modbus RTU model  return("X-147") 
+# Modbus RTU model  return("X-147")
             return hwid
 
     def get_controller_name(self, controller):
@@ -413,7 +413,12 @@ class UponorStateProxy:
         var = 'cust_' + controller.replace('C', 'Controller') + '_Name'
         if var in self._data:
             return self._data[var]
-        return self._storage_metadata.get("controller_names", {}).get(controller)
+        cached_name = self._storage_metadata.get("controller_names", {}).get(controller)
+        if cached_name:
+            return cached_name
+        # Fall back to a generated name ("<gateway name> Controller 1") so
+        # controller devices are never registered unnamed.
+        return f"{self.get_integration_name()} {controller.replace('C', 'Controller ')}"
 
     def get_integration_name(self) -> str:
         """Return the user-configured name for this integration instance (gateway)."""

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -614,18 +614,19 @@ class UponorStateProxy:
 
     def get_thermostat_model(self, thermostat):
         var = thermostat + '_thermostat_type'
-        if var in self._data:
-            hwid = int(self._data[var])
-            sn = self.get_thermostat_id(thermostat)[:4]
-            prodk = sn[:3]
-            mod = sn[-1:]
-      
-            if prodk=="269":
-                if mod=="1":
-                    return ('T-144')
-                if mod=="2":
-                    return ('T-145')
-            _LOGGER.debug(f"id {hwid} s/n start {sn} rh_c {self.has_humidity_control(thermostat)} rh_s {self.has_humidity_sensor(thermostat)} pd {self.is_public_device(thermostat)} hft {self.has_floor_temperature(thermostat)} Sensor only {self.is_sensor_only(thermostat)}")
+        if var not in self._data:
+            return None
+        hwid = int(self._data[var])
+        sn = self.get_thermostat_id(thermostat)[:4]
+        prodk = sn[:3]
+        mod = sn[-1:]
+
+        if prodk=="269":
+            if mod=="1":
+                return ('T-144')
+            if mod=="2":
+                return ('T-145')
+        _LOGGER.debug(f"id {hwid} s/n start {sn} rh_c {self.has_humidity_control(thermostat)} rh_s {self.has_humidity_sensor(thermostat)} pd {self.is_public_device(thermostat)} hft {self.has_floor_temperature(thermostat)} Sensor only {self.is_sensor_only(thermostat)}")
 # Smartix Base Pulse                   
 #                   return("T-141") #No temp adjustment/RH
 #                   return("T-143") #No temp adjustment/External temp/Tamper Alarm

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -45,7 +45,8 @@ from .const import (
     STATUS_ERROR_MAINCONTROLER_FAIL,
     TOO_HIGH_TEMP_LIMIT,
     DEFAULT_TEMP,
-    DEVICE_MANUFACTURER
+    DEVICE_MANUFACTURER,
+    DIAL_THERMOSTAT_MODELS
 )
 from .jnap import UponorJnap
 from .helper import get_unique_id_from_config_entry, _get_mac_with_arp_refresh 
@@ -583,6 +584,14 @@ class UponorStateProxy:
                     if (room_name := self._get_room_name_from_data(thermostat))
                 },
             },
+            "models": {
+                **self._storage_metadata.get("models", {}),
+                **{
+                    thermostat: model
+                    for thermostat in thermostats
+                    if (model := self._detect_thermostat_model(thermostat))
+                },
+            },
             "humidity": list(dict.fromkeys(
                 [thermostat for thermostat in thermostats if thermostat + '_rh' in self._data and int(self._data[thermostat + '_rh']) != 0]
                 + self._storage_metadata.get("humidity", [])
@@ -636,6 +645,14 @@ class UponorStateProxy:
         return thermostat
 
     def get_thermostat_model(self, thermostat):
+        model = self._detect_thermostat_model(thermostat)
+        if model is not None:
+            return model
+        # Fall back to the cached detection so the model (and the gating that
+        # depends on it) is available before the first live update.
+        return self._storage_metadata.get("models", {}).get(thermostat)
+
+    def _detect_thermostat_model(self, thermostat):
         var = thermostat + '_thermostat_type'
         if var not in self._data:
             return None
@@ -784,12 +801,7 @@ class UponorStateProxy:
         return int(self._data[var]) * mode
 
     def requires_local_override(self, thermostat):
-        # T-144/T-145 dial thermostats accept remote setpoint changes only
-        # while local override is enabled. Detection mirrors
-        # get_thermostat_model but works from the cached thermostat id, so it
-        # is usable before the first live update.
-        sn = str(self.get_thermostat_id(thermostat))[:4]
-        return sn[:3] == "269" and sn[3:4] in ("1", "2")
+        return self.get_thermostat_model(thermostat) in DIAL_THERMOSTAT_MODELS
 
     def get_local_override(self, thermostat):
         var = thermostat + '_pub_setpoint_override'

--- a/custom_components/uponorx265/climate.py
+++ b/custom_components/uponorx265/climate.py
@@ -115,10 +115,10 @@ class UponorClimate(UponorThermostatEntity, ClimateEntity):
     def preset_mode(self):
         if self._state_proxy.get_local_override(self._thermostat):
             return PRESET_MANUAL
-        if self._state_proxy.is_eco(self._thermostat):
-            return PRESET_ECO
         if self._state_proxy.is_away():
             return PRESET_AWAY
+        if self._state_proxy.is_eco(self._thermostat):
+            return PRESET_ECO
         return PRESET_COMFORT
 
     @property
@@ -161,13 +161,7 @@ class UponorClimate(UponorThermostatEntity, ClimateEntity):
             # Turn off manual override if we switch to another preset
             if self._state_proxy.get_local_override(self._thermostat):
                 await self._state_proxy.async_local_override(self._thermostat, False)
-            if preset_mode == PRESET_ECO:
-                if self._state_proxy.is_away():
-                    await self._state_proxy.async_set_preset_mode(PRESET_COMFORT)
-                else:
-                    await self._state_proxy.async_set_preset_mode(PRESET_AWAY)
-            else:
-                await self._state_proxy.async_set_preset_mode(preset_mode)
+            await self._state_proxy.async_set_preset_mode(preset_mode)
 
     # T-144/T-145 dial thermostats ignore remote setpoint changes unless
     # local override is enabled first; other models accept them directly.

--- a/custom_components/uponorx265/climate.py
+++ b/custom_components/uponorx265/climate.py
@@ -178,4 +178,4 @@ class UponorClimate(UponorThermostatEntity, ClimateEntity):
             )
         temp = kwargs.get(ATTR_TEMPERATURE)
         if temp is not None and self._is_on:
-            await self._state_proxy.async_set_setpoint(self._thermostat, temp)
+            await self._state_proxy.async_set_target_temperature(self._thermostat, temp)

--- a/custom_components/uponorx265/climate.py
+++ b/custom_components/uponorx265/climate.py
@@ -45,7 +45,6 @@ class UponorClimate(UponorThermostatEntity, ClimateEntity):
     _enable_turn_on_off_backwards_compatibility = False
     _attr_name = None  # Main entity — uses device name directly
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_preset_modes = [PRESET_COMFORT, PRESET_ECO, PRESET_AWAY, PRESET_MANUAL]
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.PRESET_MODE
@@ -58,6 +57,12 @@ class UponorClimate(UponorThermostatEntity, ClimateEntity):
         self._is_on = True
         self._update_power_state()
         self._attr_unique_id = f"{unique_instance_id}_{state_proxy.get_thermostat_id(thermostat)}_climate"
+        # The 'HA controlled' preset (local override) only exists on
+        # T-144/T-145 dial thermostats.
+        self._requires_local_override = state_proxy.requires_local_override(thermostat)
+        self._attr_preset_modes = [PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
+        if self._requires_local_override:
+            self._attr_preset_modes.append(PRESET_MANUAL)
 
     def _update_power_state(self):
         temp_raw = self._state_proxy.get_setpoint_raw(self._thermostat)
@@ -113,7 +118,7 @@ class UponorClimate(UponorThermostatEntity, ClimateEntity):
     
     @property
     def preset_mode(self):
-        if self._state_proxy.get_local_override(self._thermostat):
+        if self._requires_local_override and self._state_proxy.get_local_override(self._thermostat):
             return PRESET_MANUAL
         if self._state_proxy.is_away():
             return PRESET_AWAY
@@ -163,12 +168,8 @@ class UponorClimate(UponorThermostatEntity, ClimateEntity):
                 await self._state_proxy.async_local_override(self._thermostat, False)
             await self._state_proxy.async_set_preset_mode(preset_mode)
 
-    # T-144/T-145 dial thermostats ignore remote setpoint changes unless
-    # local override is enabled first; other models accept them directly.
-    _MODELS_REQUIRING_LOCAL_OVERRIDE = ("T-144", "T-145")
-
     async def async_set_temperature(self, **kwargs):
-        if (self._state_proxy.get_thermostat_model(self._thermostat) in self._MODELS_REQUIRING_LOCAL_OVERRIDE
+        if (self._requires_local_override
                 and not self._state_proxy.get_local_override(self._thermostat)):
             self.hass.async_create_task(self._state_proxy.async_update())
             raise ServiceValidationError(

--- a/custom_components/uponorx265/climate.py
+++ b/custom_components/uponorx265/climate.py
@@ -169,8 +169,13 @@ class UponorClimate(UponorThermostatEntity, ClimateEntity):
             else:
                 await self._state_proxy.async_set_preset_mode(preset_mode)
 
+    # T-144/T-145 dial thermostats ignore remote setpoint changes unless
+    # local override is enabled first; other models accept them directly.
+    _MODELS_REQUIRING_LOCAL_OVERRIDE = ("T-144", "T-145")
+
     async def async_set_temperature(self, **kwargs):
-        if not self._state_proxy.get_local_override(self._thermostat):
+        if (self._state_proxy.get_thermostat_model(self._thermostat) in self._MODELS_REQUIRING_LOCAL_OVERRIDE
+                and not self._state_proxy.get_local_override(self._thermostat)):
             self.hass.async_create_task(self._state_proxy.async_update())
             raise ServiceValidationError(
                 translation_domain="uponorx265",

--- a/custom_components/uponorx265/const.py
+++ b/custom_components/uponorx265/const.py
@@ -31,6 +31,10 @@ STATUS_OFFLINE                  = 'offline'
 STATUS_ERROR_MAINCONTROLER_FAIL = 'comfail_main_controller'
 PRESET_MANUAL = 'ha_controlled'
 
+# Dial thermostats accept remote setpoint changes only while local override
+# is enabled; all other models accept them directly.
+DIAL_THERMOSTAT_MODELS = ("T-144", "T-145")
+
 CONF_CREATE_CONTROLLERS = "create_controllers"
 CONF_SENSOR_TEMP = "sensor_temperature"
 CONF_BINARY_SENSOR_VALVE = "binary_sensor_valve"

--- a/custom_components/uponorx265/manifest.json
+++ b/custom_components/uponorx265/manifest.json
@@ -9,9 +9,9 @@
   ],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/fjonson95/uponorX265",
+  "documentation": "https://github.com/dave-code-ruiz/uponorX265",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/fjonson95/uponorX265/issues",
+  "issue_tracker": "https://github.com/dave-code-ruiz/uponorX265/issues",
   "requirements": [
     "getmac"
   ],

--- a/custom_components/uponorx265/strings.json
+++ b/custom_components/uponorx265/strings.json
@@ -115,7 +115,7 @@
   },
   "exceptions": {
     "temperature_not_controllable": {
-      "message": "{room_name}: temperature is controlled by the physical thermostat dial. Switch to the 'HA-styrd' preset to set temperature from Home Assistant."
+      "message": "{room_name}: temperature is controlled by the physical thermostat dial. Switch to the 'HA controlled' preset to set temperature from Home Assistant."
     }
   },
   "entity": {

--- a/custom_components/uponorx265/switch.py
+++ b/custom_components/uponorx265/switch.py
@@ -22,8 +22,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
         entities.append(CoolSwitch(unique_id, state_proxy))
 
     for thermostat in hass.data[unique_id]["thermostats"]:
-        entities.append(LocalOverride(unique_id, state_proxy, thermostat))
-        
+        # The local override switch only exists on T-144/T-145 dial thermostats.
+        if state_proxy.requires_local_override(thermostat):
+            entities.append(LocalOverride(unique_id, state_proxy, thermostat))
+
         if entry.data.get(CONF_SWITCH_SENSOR_AVG, False):
             entities.append(ClimatControlInAvg(unique_id, state_proxy, thermostat))
 

--- a/custom_components/uponorx265/translations/en.json
+++ b/custom_components/uponorx265/translations/en.json
@@ -115,7 +115,7 @@
   },
   "exceptions": {
     "temperature_not_controllable": {
-      "message": "{room_name}: temperature is controlled by the physical thermostat dial. Switch to the 'HA-styrd' preset to set temperature from Home Assistant."
+      "message": "{room_name}: temperature is controlled by the physical thermostat dial. Switch to the 'HA controlled' preset to set temperature from Home Assistant."
     }
   },
   "entity": {


### PR DESCRIPTION
## Summary

Fixes for regressions introduced in 1.1.5–1.1.7, one commit per issue.

### Upgrade path
- **Migrate climate unique_ids to the 1.1.5 `_climate`-suffixed format.** Updating from ≤1.1.4
  orphaned every climate entity and created duplicates, breaking automations, dashboards and
  history. Entities are now renamed in place (entity_ids and history preserved). Users who
  already updated through 1.1.5–1.1.7 get their stale duplicate entries cleaned up instead.

### Regressions
- **Temperature can be set again on non-dial thermostats.** The local-override requirement in
  `async_set_temperature` now applies only to T-144/T-145 dial models, not to every thermostat.
- **Restore non-blocking startup** when cached thermostats exist (`if config_entry.entry_id:`
  is always true, so setup always blocked on a full gateway poll).
- **Fix NameError in `get_thermostat_model`** when called before the first successful update.

### Behavior
- **ECO preset selects eco mode** instead of toggling away on/off; away is reported over
  per-room eco since it is the broader state.
- **Changing target temperature during eco/away adjusts the eco offset** so the effective
  target matches what the user set, instead of shifting the comfort setpoint underneath
  the setback.

### Entities & device registry
- **Local-override switch and "HA controlled" preset are created only for dial thermostats**
  (they are inert on all other models). Stale switches from 1.1.5–1.1.7 are removed after the
  first poll. Dial-model detection lives in one place and is cached, so it also works on
  cache-based startups.
- **Unmapped models report no model** instead of the raw `hardware_type` value, which is a
  device class (1=controller, 2=thermostat), not a model id — and an int, which HA rejects
  from 2026.12. Note: serial-digit model detection does not generalize (a uniform T-169
  fleet spans serial prefixes 2855/2858/2860), so unknown models are left empty rather
  than guessed.
- **Controller devices get a generated fallback name** ("Uponor Controller 1") when no name
  is configured or provided by the system, instead of registering unnamed.
- Manifest `documentation`/`issue_tracker` point back to this repository; fixed Swedish text
  leaking into the English `temperature_not_controllable` message.

## Testing

Live upgrade from 1.1.4 on an X-265/R-208 system (3 controllers, 16 T-169 thermostats):
all entities migrated in place with entity_ids and history intact, no duplicates,
temperature/preset/setback behavior verified, no registry warnings.
