### PR TITLE
Fix rooms stuck off (storage race, poisoned memo, discarded set_temperature) and via_device ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 .github/
 .ignore_these/
+ARCHITECTURE_sv.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,10 +5,11 @@ Home Assistant custom integration that connects to an **Uponor Smatrix Pulse** g
 ## Contents
 
 1. [Architecture](#architecture)
-2. [Functionality](#functionality)
-3. [Official Pulse app (reference)](#official-pulse-app-reference)
-4. [Raw data (JNAP variables)](#raw-data-jnap-variables)
-5. [Supported hardware](#supported-hardware)
+2. [Testing](#testing)
+3. [Functionality](#functionality)
+4. [Official Pulse app (reference)](#official-pulse-app-reference)
+5. [Raw data (JNAP variables)](#raw-data-jnap-variables)
+6. [Supported hardware](#supported-hardware)
 
 ---
 
@@ -29,7 +30,19 @@ The gateway's `device_info` identifier and serial number are based on its MAC ad
 
 **Important limitation:** ARP only works within the same broadcast domain/subnet. If the HA host and the gateway are on different subnets/VLANs, the MAC address can never be resolved (the kernel never gets an ARP entry for it), and it permanently falls back to the host-based ID — this is not a code bug, it's a network topology limitation.
 
-Since the gateway ID's format can change over time (host-based → lowercase MAC → uppercase MAC, in the order the integration has evolved), `_migrate_gateway_device_id()` handles the transition: it finds the old device entry in the device registry and renames its identifier in place if no new entry exists, or carries over the area/custom name and removes the old entry if a new one was already created by a prior restart. This runs on every startup and is idempotent.
+Since the gateway ID's format can change over time (host-based → lowercase MAC → uppercase MAC, in the order the integration has evolved) — and the host-based fallback itself can drift across restarts if MAC resolution keeps failing while DHCP reassigns the IP — `_migrate_gateway_device_id()` handles the transition. Rather than guessing at specific old id strings (which would miss that drift), it identifies the old device *structurally*: for a given config entry there is exactly one device with no `via_device` (the root of the gateway/controller/thermostat hierarchy), whatever identifier it currently happens to hold. It renames that device's identifier in place if no device already exists under the new identifier, or carries over the area/custom name and removes the old device if one does (created by a prior restart before this reconciliation ran). This runs on every startup and is idempotent.
+
+### Device registration ordering — [__init__.py](custom_components/uponorx265/__init__.py)
+Thermostat and controller entities declare a `via_device` pointing at their parent (controller, then gateway) in their `device_info`. Historically the parent device only ever got created as a side effect of a specific entity — a controller status sensor, gated behind the optional `CONF_CREATE_CONTROLLERS` — which lives in the `SENSOR` platform, loaded *after* `CLIMATE` and `SWITCH` in `PLATFORMS`. HA would log a `via_device` referencing a non-existing device warning and eventually stop honoring it, and if the controller sensor was disabled the parent device was never created at all.
+
+`_register_gateway_devices()` fixes this by registering the gateway and controller devices explicitly in `async_setup_entry`, before `async_forward_entry_setups()` is called — so the parent always exists regardless of platform order or which optional entities are enabled. It falls back to `get_cached_controllers()` (mirroring `get_cached_thermostats()`) when live data isn't loaded yet, e.g. on a warm restart where `async_update()` runs as a background task instead of being awaited.
+
+### Setpoint storage & restore-on-off — [__init__.py](custom_components/uponorx265/__init__.py) / [climate.py](custom_components/uponorx265/climate.py)
+The integration has no real on/off register — "off" is encoded as `setpoint == min_temp` (or `max_temp` in cool mode). The `.storage` file's per-thermostat setpoint memo is therefore the only thing that can restore a room to its pre-off temperature, which makes its read-modify-write path load-bearing:
+
+- **`self._storage_lock`** (`asyncio.Lock`) serialises every read-modify-write against `_storage_data`: `async_turn_off()`, `async_remember_setpoint()`, and the metadata-refresh save in `_async_persist_discovery_metadata()` all take it. Without this, HA turning off several thermostats in one service call runs those coroutines concurrently; each would load its own fresh copy of the storage dict, mutate only its own key, and save — last writer wins, silently discarding every other room's memo.
+- **`async_turn_off()`** never memorises the off value (`min_temp`/`max_temp`) itself as the restore target — doing so would permanently strand the room off, since `async_turn_on()` would just write the off value straight back. **`async_turn_on()`** also treats a previously-poisoned memo (one that does equal the off value, e.g. left over from before this fix) as "no memo" and falls back to `DEFAULT_TEMP` instead of restoring it.
+- **`async_remember_setpoint()`** backs `UponorClimate.async_set_temperature()` when the room is off: rather than silently discarding the request (the old behavior) or writing the live setpoint through (which would silently turn the room back on, violating `hvac_mode: off`), it records the requested temperature in storage so the next `turn_on` restores exactly what was asked for.
 
 ### Entity base — [helper.py](custom_components/uponorx265/helper.py)
 Three base classes build a device hierarchy in HA:
@@ -55,6 +68,33 @@ One file per HA domain; each reads `hass.data[unique_id]` for the state_proxy + 
 | [config_flow.py](custom_components/uponorx265/config_flow.py) | Setup wizard + options flow (host, controller names, room names, feature toggles) |
 
 ---
+
+## Testing
+
+A `pytest` suite lives under [tests/](tests/), using `pytest-homeassistant-custom-component` for a real (in-memory) `hass` instance — the JNAP client is always mocked, no real network calls are made. Run with:
+
+```
+pip install -r requirements_test.txt
+pytest tests/ -v
+```
+
+`tests/helpers.py` provides `make_state_proxy()`, which builds a `UponorStateProxy` backed by a mocked `UponorJnap` client and a `hass`-backed `Store`, and `thermostat_data()` for constructing raw `_data` entries at a given setpoint/limits.
+
+The suite is weighted towards regression coverage for bugs found during review rather than exhaustive coverage of the whole integration:
+
+| File | Covers |
+|---|---|
+| [test_turn_off_storage_race.py](tests/test_turn_off_storage_race.py) | The storage lock — concurrent `async_turn_off()` calls must not lose each other's memo |
+| [test_poisoned_memo.py](tests/test_poisoned_memo.py) | The off value is never memorised as a restore target, and a poisoned memo self-heals on `turn_on` |
+| [test_set_temperature_while_off.py](tests/test_set_temperature_while_off.py) | `set_temperature` on an off room is remembered, not silently discarded |
+| [test_device_registration.py](tests/test_device_registration.py) | Gateway/controller devices exist before platform setup, regardless of `CONF_CREATE_CONTROLLERS` |
+| [test_gateway_device_migration.py](tests/test_gateway_device_migration.py) | The gateway device migration finds the old device structurally, including after host-id drift |
+| [test_bypass_max_two.py](tests/test_bypass_max_two.py) | The max-2-bypass-zones-per-controller business rule, and that it's per-controller not global |
+| [test_thermostat_model_detection.py](tests/test_thermostat_model_detection.py) | The `hwid`/serial-prefix model detection heuristic and its cache fallback |
+
+Note on the storage-race test specifically: `pytest-homeassistant-custom-component`'s mocked `Store.async_save` never actually suspends (no executor read, no disk write), so without an explicit forced yield point (`asyncio.sleep(0)` injected into the mock) the test can pass "by accident" on platforms/schedulers where the mocked coroutines happen to run to completion sequentially anyway — masking a regression instead of catching it. The injected yield point makes the test deterministic regardless of platform.
+
+Windows-specific: `tests/conftest.py` neutralises `pytest_socket.disable_socket()`, which `pytest-homeassistant-custom-component` calls unconditionally before every test. On Windows, asyncio's event loop needs a real socketpair for its internal self-pipe, so blocking all sockets breaks fixture setup before any test code runs; since no test here makes real network calls anyway, this is safe to disable rather than fight.
 
 ## Functionality
 

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -159,19 +159,22 @@ def _migrate_entity_unique_ids(hass: HomeAssistant, config_entry: ConfigEntry, u
                 entry.entity_id, entry.unique_id, exc,
             )
 
-def _migrate_gateway_device_id(hass: HomeAssistant, unique_instance_id: str, host: str, new_gateway_id: str) -> None:
+def _migrate_gateway_device_id(hass: HomeAssistant, config_entry: ConfigEntry, unique_instance_id: str, new_gateway_id: str) -> None:
     """Reconcile the gateway device's identifier with a newly-resolved MAC.
 
-    Historical identifier formats for the gateway device, in order:
-    - host-based (host with dots stripped) — used before MAC resolution was wired up
-    - lowercase MAC (no separators) — used before the id was uppercased
-    Any of these may still be registered as the gateway device's identifier.
-    Once resolution lands on the current format, entities switch to it and
-    Home Assistant would otherwise create a *new* device for them, leaving
-    the old one orphaned (no entities). This merges them: rename in place if
-    only an old-format device exists, or drop the orphaned old one (after
-    copying over any user customization) if a new device already exists from
-    a prior restart.
+    The gateway device's identifier has changed format over time (host-based
+    with dots stripped -> lowercase MAC -> uppercase MAC), and the host-based
+    fallback itself can drift across restarts (DHCP reassigning the IP while
+    MAC resolution keeps failing, e.g. gateway and HA host on different
+    subnets — see the "Gateway ID" section of ARCHITECTURE.md). Guessing at
+    specific old id strings would miss that drift and leave a fresh orphaned
+    device behind on every IP change. Instead, this identifies the gateway
+    device structurally: for a given config entry there is exactly one
+    device with no via_device (the root of the gateway/controller/thermostat
+    hierarchy) — whatever identifier it currently holds, that's the old
+    gateway device to reconcile. Renames it in place if no device already
+    exists under the new identifier, or drops it (after copying over any
+    user customization) if one does.
     """
     if new_gateway_id is None:
         return
@@ -180,37 +183,70 @@ def _migrate_gateway_device_id(hass: HomeAssistant, unique_instance_id: str, hos
     new_identifier = (unique_instance_id, new_gateway_id)
     new_device = dev_reg.async_get_device(identifiers={new_identifier})
 
-    old_candidate_ids = {host.replace('.', ''), new_gateway_id.lower()} - {new_gateway_id}
-    for old_gateway_id in old_candidate_ids:
-        old_identifier = (unique_instance_id, old_gateway_id)
-        old_device = dev_reg.async_get_device(identifiers={old_identifier})
-        if old_device is None:
-            continue
+    old_device = next(
+        (
+            device
+            for device in device_registry.async_entries_for_config_entry(dev_reg, config_entry.entry_id)
+            if device.via_device_id is None and new_identifier not in device.identifiers
+        ),
+        None,
+    )
+    if old_device is None:
+        return
 
-        if new_device is None:
-            # First time resolving to this format: rename the existing device in place.
-            updated_identifiers = {
-                new_identifier if i == old_identifier else i for i in old_device.identifiers
-            }
-            dev_reg.async_update_device(old_device.id, new_identifiers=updated_identifiers)
-            _LOGGER.info(
-                "Migrated gateway device identifier for %s: '%s' -> '%s'",
-                unique_instance_id, old_gateway_id, new_gateway_id,
-            )
-            new_device = dev_reg.async_get_device(identifiers={new_identifier})
-            continue
-
-        # A new device already exists (created by a prior restart before this
-        # migration existed). Carry over any user customization, then drop the
-        # now-empty old device.
-        if old_device.area_id and not new_device.area_id:
-            dev_reg.async_update_device(new_device.id, area_id=old_device.area_id)
-        if old_device.name_by_user and not new_device.name_by_user:
-            dev_reg.async_update_device(new_device.id, name_by_user=old_device.name_by_user)
-        dev_reg.async_remove_device(old_device.id)
+    if new_device is None:
+        # First time resolving to this identifier: rename the existing device in place.
+        dev_reg.async_update_device(old_device.id, new_identifiers={new_identifier})
         _LOGGER.info(
-            "Removed orphaned gateway device '%s' (%s) for %s, superseded by '%s'",
-            old_gateway_id, old_device.id, unique_instance_id, new_gateway_id,
+            "Migrated gateway device identifier for %s to '%s'",
+            unique_instance_id, new_gateway_id,
+        )
+        return
+
+    # A new device already exists (created by a prior restart). Carry over
+    # any user customization, then drop the now-orphaned old device.
+    if old_device.area_id and not new_device.area_id:
+        dev_reg.async_update_device(new_device.id, area_id=old_device.area_id)
+    if old_device.name_by_user and not new_device.name_by_user:
+        dev_reg.async_update_device(new_device.id, name_by_user=old_device.name_by_user)
+    dev_reg.async_remove_device(old_device.id)
+    _LOGGER.info(
+        "Removed orphaned gateway device (%s) for %s, superseded by '%s'",
+        old_device.id, unique_instance_id, new_gateway_id,
+    )
+
+
+def _register_gateway_devices(hass: HomeAssistant, config_entry: ConfigEntry, unique_instance_id: str, state_proxy) -> None:
+    """Explicitly register the gateway and controller devices before platform setup.
+
+    Thermostat/controller entities declare a `via_device` pointing at their
+    parent, but the parent device is otherwise only created as a side effect
+    of a specific entity (a controller sensor, gated behind
+    CONF_CREATE_CONTROLLERS) which may load after — or never, if that entity
+    is disabled. Registering the devices up front guarantees the parent
+    always exists regardless of platform order or which optional entities
+    are enabled.
+    """
+    dev_reg = device_registry.async_get(hass)
+    dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(unique_instance_id, state_proxy.get_gateway_id())},
+        manufacturer=DEVICE_MANUFACTURER,
+        name=state_proxy.get_integration_name(),
+        model=state_proxy.get_model(),
+        serial_number=state_proxy.get_gateway_id(),
+    )
+    controllers = state_proxy.get_active_controllers() or state_proxy.get_cached_controllers()
+    for controller in controllers:
+        dev_reg.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={(unique_instance_id, state_proxy.get_controller_id(controller))},
+            manufacturer=DEVICE_MANUFACTURER,
+            name=state_proxy.get_controller_name(controller),
+            model=state_proxy.get_controller_hardware(controller),
+            sw_version=state_proxy.get_controller_version(controller),
+            serial_number=state_proxy.get_controller_id(controller),
+            via_device=(unique_instance_id, state_proxy.get_gateway_id()),
         )
 
 
@@ -262,7 +298,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     # Must run before platform setup: device_info reads get_gateway_id(),
     # which otherwise falls back to a host-based id for the entire session.
     resolved_gateway_id = await state_proxy.async_resolve_gateway_id()
-    _migrate_gateway_device_id(hass, unique_id, host, resolved_gateway_id)
+    _migrate_gateway_device_id(hass, config_entry, unique_id, resolved_gateway_id)
 
     hass.data[unique_id] = {
         "state_proxy": state_proxy,
@@ -291,6 +327,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     # Must run before platform setup so HA matches existing registry entries
     # to the new unique_ids instead of creating duplicate entities.
     _migrate_entity_unique_ids(hass, config_entry, unique_id)
+
+    # Register gateway/controller devices before platform setup: CLIMATE and
+    # SWITCH load before SENSOR, and their entities' via_device would
+    # otherwise reference a controller device that doesn't exist yet.
+    _register_gateway_devices(hass, config_entry, unique_id, state_proxy)
 
     # Forward setup for "climate" and "switch" platforms (done outside of the event loop)
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
@@ -441,6 +482,7 @@ class UponorStateProxy:
         self._last_successful_update = None
         self._unavailable_since = None
         self._update_lock = asyncio.Lock()
+        self._storage_lock = asyncio.Lock()
         self._reload_in_progress = False
         self._last_reload_attempt = None
         self._gateway_id = None
@@ -669,6 +711,13 @@ class UponorStateProxy:
         ids = self._storage_metadata.get("ids", {})
         if isinstance(thermostats, list) and thermostats and all(ids.get(thermostat) for thermostat in thermostats):
             return thermostats
+        return []
+
+    def get_cached_controllers(self):
+        controllers = self._storage_metadata.get("controllers", [])
+        ids = self._storage_metadata.get("controller_ids", {})
+        if isinstance(controllers, list) and controllers and all(ids.get(controller) for controller in controllers):
+            return controllers
         return []
 
     def is_available(self):
@@ -1046,15 +1095,31 @@ class UponorStateProxy:
 
     async def async_turn_on(self, thermostat):
         await self.async_load_storage()
+        off_temp = self.get_max_limit(thermostat) if self.is_cool_enabled() else self.get_min_limit(thermostat)
         last_temp = self._storage_data.get(thermostat, DEFAULT_TEMP)
+        if last_temp == off_temp:
+            # A poisoned memo (recorded while already at the off value) must
+            # not strand the room off forever.
+            last_temp = DEFAULT_TEMP
         await self.async_set_setpoint(thermostat, last_temp)
 
     async def async_turn_off(self, thermostat):
-        await self.async_load_storage()
-        self._storage_data[thermostat] = self.get_setpoint(thermostat)
-        await self._store.async_save(self._compose_storage_payload())
         off_temp = self.get_max_limit(thermostat) if self.is_cool_enabled() else self.get_min_limit(thermostat)
+        current = self.get_setpoint(thermostat)
+        async with self._storage_lock:
+            await self.async_load_storage()
+            if current != off_temp:
+                # Don't record the off value itself as the restore target.
+                self._storage_data[thermostat] = current
+                await self._store.async_save(self._compose_storage_payload())
         await self.async_set_setpoint(thermostat, off_temp)
+
+    async def async_remember_setpoint(self, thermostat, temp):
+        """Record a target temperature requested while the room is off, so turn_on restores it."""
+        async with self._storage_lock:
+            await self.async_load_storage()
+            self._storage_data[thermostat] = temp
+            await self._store.async_save(self._compose_storage_payload())
 
     async def async_set_preset_mode(self, preset_mode):
         if preset_mode in (PRESET_AWAY, PRESET_ECO):

--- a/custom_components/uponorx265/__init__.py
+++ b/custom_components/uponorx265/__init__.py
@@ -802,7 +802,8 @@ class UponorStateProxy:
 
         if new_metadata != self._storage_metadata:
             self._storage_metadata = new_metadata
-            await self._store.async_save(self._compose_storage_payload())
+            async with self._storage_lock:
+                await self._store.async_save(self._compose_storage_payload())
 
     # -------------------------------------------------------------------------
     # Thermostat config

--- a/custom_components/uponorx265/climate.py
+++ b/custom_components/uponorx265/climate.py
@@ -178,5 +178,11 @@ class UponorClimate(UponorThermostatEntity, ClimateEntity):
                 translation_placeholders={"room_name": self._room_name},
             )
         temp = kwargs.get(ATTR_TEMPERATURE)
-        if temp is not None and self._is_on:
+        if temp is None:
+            return
+        if self._is_on:
             await self._state_proxy.async_set_target_temperature(self._thermostat, temp)
+        else:
+            # Room is off: remember the requested target so turn_on restores
+            # it, without turning the room back on.
+            await self._state_proxy.async_remember_setpoint(self._thermostat, temp)

--- a/custom_components/uponorx265/manifest.json
+++ b/custom_components/uponorx265/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "getmac"
   ],
-  "version": "1.1.9"
+  "version": "1.1.10"
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests
+addopts = --force-enable-socket

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+pytest-homeassistant-custom-component
+pytest-asyncio
+tzdata; sys_platform == "win32"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+import pytest_socket
+
+# pytest-homeassistant-custom-component unconditionally calls
+# pytest_socket.disable_socket() before every test. On Windows, asyncio's
+# event loop needs a real socketpair for its internal self-pipe, so blocking
+# all sockets breaks fixture setup before any test code runs. We don't make
+# real network calls in these tests (the JNAP client is always mocked), so
+# disable that safety net rather than fight the event loop over it.
+pytest_socket.disable_socket = lambda *args, **kwargs: None
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    yield

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,47 @@
+"""Shared test helpers for constructing an UponorStateProxy without real network/storage I/O."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.helpers.storage import Store
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.uponorx265 import UponorStateProxy
+from custom_components.uponorx265.const import DOMAIN, STORAGE_KEY, STORAGE_VERSION
+
+# A single thermostat's setpoint/limits, matching Uponor's raw encoding
+# (raw = degrees_C * 18 + 320). Heating mode, min 15.0 / max 25.0 as in the
+# bug report's reproduction environment.
+MIN_TEMP_RAW = 590   # 15.0 C
+MAX_TEMP_RAW = 770   # 25.0 C
+
+
+def raw_for(temp_c: float) -> int:
+    return round(temp_c * 18 + 320)
+
+
+def make_state_proxy(hass, data=None, entry_data=None, unique_id="uponorx265_test"):
+    """Build an UponorStateProxy with a mocked JNAP client and hass-backed Store.
+
+    Network calls (send_data) are captured on proxy._client.send_data instead
+    of hitting a real gateway.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=entry_data or {}, unique_id=unique_id)
+    entry.add_to_hass(hass)
+
+    store = Store(hass, STORAGE_VERSION, f"{STORAGE_KEY}_{unique_id}")
+    proxy = UponorStateProxy(hass, "10.0.0.1", None, store, unique_id, entry)
+    proxy._client = AsyncMock()
+
+    if data:
+        proxy._data.update(data)
+
+    return proxy
+
+
+def thermostat_data(thermostat: str, setpoint_c: float, min_c: float = 15.0, max_c: float = 25.0) -> dict:
+    """Raw _data entries for one thermostat at the given setpoint/limits."""
+    return {
+        f"{thermostat}_setpoint": raw_for(setpoint_c),
+        f"{thermostat}_minimum_setpoint": raw_for(min_c),
+        f"{thermostat}_maximum_setpoint": raw_for(max_c),
+    }

--- a/tests/test_bypass_max_two.py
+++ b/tests/test_bypass_max_two.py
@@ -1,0 +1,61 @@
+"""BypassEnableSwitch must enforce Uponor's own limit of max 2 active bypass
+zones per controller (confirmed against the official app's own documented
+limit, see ARCHITECTURE.md), and must count per-controller, not globally.
+"""
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.uponorx265.switch import BypassEnableSwitch
+
+from tests.helpers import make_state_proxy
+
+UNIQUE_ID = "uponorx265_test"
+C1_THERMOSTATS = ["C1_T1", "C1_T2", "C1_T3"]
+C2_THERMOSTATS = ["C2_T1"]
+
+
+def make_switch(hass, proxy, thermostat, all_thermostats):
+    hass.data[UNIQUE_ID] = {"thermostats": all_thermostats}
+    entity = BypassEnableSwitch(UNIQUE_ID, proxy, thermostat)
+    entity.hass = hass
+    entity.async_write_ha_state = lambda: None  # not added to a platform in this test
+    return entity
+
+
+async def test_third_bypass_on_same_controller_is_rejected(hass):
+    proxy = make_state_proxy(hass, unique_id=UNIQUE_ID)
+    proxy._data["C1_T1_bypass_enable"] = "1"
+    proxy._data["C1_T2_bypass_enable"] = "1"
+
+    entity = make_switch(hass, proxy, "C1_T3", C1_THERMOSTATS + C2_THERMOSTATS)
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_turn_on()
+
+    proxy._client.send_data.assert_not_called()
+
+
+async def test_second_bypass_on_same_controller_is_allowed(hass):
+    proxy = make_state_proxy(hass, unique_id=UNIQUE_ID)
+    proxy._data["C1_T1_bypass_enable"] = "1"
+
+    entity = make_switch(hass, proxy, "C1_T2", C1_THERMOSTATS + C2_THERMOSTATS)
+
+    await entity.async_turn_on()
+
+    proxy._client.send_data.assert_called_once_with({"C1_T2_bypass_enable": "1"})
+
+
+async def test_limit_is_per_controller_not_global(hass):
+    # C1 already has 2 active bypasses; C2 has none. Enabling on C2 must not
+    # be blocked by C1's count.
+    proxy = make_state_proxy(hass, unique_id=UNIQUE_ID)
+    proxy._data["C1_T1_bypass_enable"] = "1"
+    proxy._data["C1_T2_bypass_enable"] = "1"
+
+    entity = make_switch(hass, proxy, "C2_T1", C1_THERMOSTATS + C2_THERMOSTATS)
+
+    await entity.async_turn_on()
+
+    proxy._client.send_data.assert_called_once_with({"C2_T1_bypass_enable": "1"})

--- a/tests/test_device_registration.py
+++ b/tests/test_device_registration.py
@@ -1,0 +1,63 @@
+"""Bug D: gateway/controller devices must exist before platforms build entities.
+
+Thermostat and controller entities declare a `via_device` pointing at their
+parent (controller, then gateway), but the parent device was previously only
+created as a side effect of a specific entity (a controller status sensor,
+gated behind CONF_CREATE_CONTROLLERS, living in a platform that loads after
+CLIMATE/SWITCH). _register_gateway_devices() must create both devices up
+front, regardless of platform order or which optional entities are enabled.
+"""
+
+from homeassistant.helpers import device_registry as dr
+
+from custom_components.uponorx265 import _register_gateway_devices
+from tests.helpers import make_state_proxy
+
+UNIQUE_ID = "uponorx265_test"
+GATEWAY_ID = "AABBCCDDEEFF"
+CONTROLLER_ID = "419524869"
+
+
+async def test_gateway_and_controller_devices_exist_before_platform_setup(hass):
+    proxy = make_state_proxy(
+        hass,
+        data={
+            "sys_controller_1_presence": "1",
+            "controller1_id": CONTROLLER_ID,
+        },
+        unique_id=UNIQUE_ID,
+    )
+    proxy._gateway_id = GATEWAY_ID  # pretend MAC resolution already ran
+
+    _register_gateway_devices(hass, proxy._config_entry, UNIQUE_ID, proxy)
+
+    dev_reg = dr.async_get(hass)
+    gateway_device = dev_reg.async_get_device(identifiers={(UNIQUE_ID, GATEWAY_ID)})
+    controller_device = dev_reg.async_get_device(identifiers={(UNIQUE_ID, CONTROLLER_ID)})
+
+    assert gateway_device is not None, "gateway device was not registered before platform setup"
+    assert controller_device is not None, "controller device was not registered before platform setup"
+    assert controller_device.via_device_id == gateway_device.id, (
+        "controller device's via_device does not point at the (now-existing) gateway device"
+    )
+
+
+async def test_controller_device_registered_even_when_controller_sensor_disabled(hass):
+    # CONF_CREATE_CONTROLLERS is not in entry_data at all here — the optional
+    # controller status sensor that used to be the only thing creating this
+    # device would never run.
+    proxy = make_state_proxy(
+        hass,
+        data={
+            "sys_controller_1_presence": "1",
+            "controller1_id": CONTROLLER_ID,
+        },
+        entry_data={},
+        unique_id=UNIQUE_ID,
+    )
+    proxy._gateway_id = GATEWAY_ID
+
+    _register_gateway_devices(hass, proxy._config_entry, UNIQUE_ID, proxy)
+
+    dev_reg = dr.async_get(hass)
+    assert dev_reg.async_get_device(identifiers={(UNIQUE_ID, CONTROLLER_ID)}) is not None

--- a/tests/test_gateway_device_migration.py
+++ b/tests/test_gateway_device_migration.py
@@ -1,0 +1,152 @@
+"""_migrate_gateway_device_id must reconcile the gateway device across any
+prior identifier — historical format changes (host-based -> lowercase MAC ->
+uppercase MAC) *and* host drift (DHCP reassigning the IP while MAC
+resolution keeps failing, e.g. gateway and HA host on different subnets) —
+without ever leaving an orphaned duplicate device behind.
+
+It identifies the old device structurally (the one device for this config
+entry with no via_device) rather than guessing specific old id strings, so
+it isn't fooled by an id it's never seen before.
+"""
+
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.uponorx265 import DOMAIN, _migrate_gateway_device_id
+
+UNIQUE_ID = "uponorx265_test"
+HOST_ID = "101683"  # "10.1.6.83".replace('.', '')
+LOWER_MAC = "28f5374ea402"
+UPPER_MAC = "28F5374EA402"
+
+
+def register_entry(hass):
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=UNIQUE_ID)
+    entry.add_to_hass(hass)
+    return entry
+
+
+def register_device(hass, entry, gateway_id, **extra):
+    dev_reg = dr.async_get(hass)
+    return dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(UNIQUE_ID, gateway_id)},
+        manufacturer="Uponor",
+        name="Floda",
+        **extra,
+    )
+
+
+async def test_renames_host_based_device_in_place(hass):
+    entry = register_entry(hass)
+    old_device = register_device(hass, entry, HOST_ID)
+
+    _migrate_gateway_device_id(hass, entry, UNIQUE_ID, UPPER_MAC)
+
+    dev_reg = dr.async_get(hass)
+    assert dev_reg.async_get_device(identifiers={(UNIQUE_ID, HOST_ID)}) is None
+    migrated = dev_reg.async_get_device(identifiers={(UNIQUE_ID, UPPER_MAC)})
+    assert migrated is not None
+    assert migrated.id == old_device.id, "should rename the existing device, not create a new one"
+
+
+async def test_renames_lowercase_mac_device_in_place(hass):
+    entry = register_entry(hass)
+    old_device = register_device(hass, entry, LOWER_MAC)
+
+    _migrate_gateway_device_id(hass, entry, UNIQUE_ID, UPPER_MAC)
+
+    dev_reg = dr.async_get(hass)
+    assert dev_reg.async_get_device(identifiers={(UNIQUE_ID, LOWER_MAC)}) is None
+    migrated = dev_reg.async_get_device(identifiers={(UNIQUE_ID, UPPER_MAC)})
+    assert migrated is not None
+    assert migrated.id == old_device.id
+
+
+async def test_renames_device_with_an_id_never_guessed_at(hass):
+    # The gateway's old identifier was based on an IP address from three
+    # restarts ago (DHCP has reassigned it twice since, while MAC resolution
+    # kept failing because the gateway is on a different subnet). Nothing in
+    # the migration logic should need to know or guess that specific string.
+    entry = register_entry(hass)
+    stale_ip_based_id = "10842217"  # some previous host, long since reassigned
+    old_device = register_device(hass, entry, stale_ip_based_id)
+
+    _migrate_gateway_device_id(hass, entry, UNIQUE_ID, UPPER_MAC)
+
+    dev_reg = dr.async_get(hass)
+    assert dev_reg.async_get_device(identifiers={(UNIQUE_ID, stale_ip_based_id)}) is None, (
+        "an id that drifted away from any known format must still be migrated, not orphaned"
+    )
+    migrated = dev_reg.async_get_device(identifiers={(UNIQUE_ID, UPPER_MAC)})
+    assert migrated is not None
+    assert migrated.id == old_device.id
+
+
+async def test_merges_duplicate_left_by_a_prior_restart(hass):
+    entry = register_entry(hass)
+    dev_reg = dr.async_get(hass)
+    old_device = register_device(hass, entry, HOST_ID)
+    old_device = dev_reg.async_update_device(old_device.id, name_by_user="Garage Gateway")
+    new_device = register_device(hass, entry, UPPER_MAC)
+
+    _migrate_gateway_device_id(hass, entry, UNIQUE_ID, UPPER_MAC)
+
+    dev_reg = dr.async_get(hass)
+    assert dev_reg.async_get_device(identifiers={(UNIQUE_ID, HOST_ID)}) is None, (
+        "orphaned old-format device must be removed, not left behind"
+    )
+    remaining = dev_reg.async_get_device(identifiers={(UNIQUE_ID, UPPER_MAC)})
+    assert remaining is not None
+    assert remaining.id == new_device.id
+    assert remaining.name_by_user == "Garage Gateway", (
+        "user customization from the old device must be carried over"
+    )
+
+
+async def test_no_op_when_no_old_device_exists(hass):
+    entry = register_entry(hass)
+
+    # Must not raise, and must not fabricate a device out of thin air —
+    # creating devices is _register_gateway_devices's job, not this one's.
+    _migrate_gateway_device_id(hass, entry, UNIQUE_ID, UPPER_MAC)
+
+    dev_reg = dr.async_get(hass)
+    assert dev_reg.async_get_device(identifiers={(UNIQUE_ID, UPPER_MAC)}) is None
+
+
+async def test_no_op_when_already_on_current_format(hass):
+    entry = register_entry(hass)
+    device = register_device(hass, entry, UPPER_MAC)
+
+    _migrate_gateway_device_id(hass, entry, UNIQUE_ID, UPPER_MAC)
+
+    dev_reg = dr.async_get(hass)
+    unchanged = dev_reg.async_get_device(identifiers={(UNIQUE_ID, UPPER_MAC)})
+    assert unchanged is not None
+    assert unchanged.id == device.id
+
+
+async def test_ignores_controller_devices_which_have_a_via_device(hass):
+    # A controller device also belongs to this config entry, but it has a
+    # via_device (pointing at the gateway) — it must never be mistaken for
+    # the gateway device itself.
+    entry = register_entry(hass)
+    dev_reg = dr.async_get(hass)
+    gateway_device = register_device(hass, entry, HOST_ID)
+    dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(UNIQUE_ID, "419524869")},
+        manufacturer="Uponor",
+        name="Controller 1",
+        via_device=(UNIQUE_ID, HOST_ID),
+    )
+
+    _migrate_gateway_device_id(hass, entry, UNIQUE_ID, UPPER_MAC)
+
+    dev_reg = dr.async_get(hass)
+    migrated = dev_reg.async_get_device(identifiers={(UNIQUE_ID, UPPER_MAC)})
+    assert migrated is not None
+    assert migrated.id == gateway_device.id
+    # The controller device is untouched.
+    assert dev_reg.async_get_device(identifiers={(UNIQUE_ID, "419524869")}) is not None

--- a/tests/test_poisoned_memo.py
+++ b/tests/test_poisoned_memo.py
@@ -1,0 +1,44 @@
+"""Bug B: a setpoint already at the off value must not be memorised as the restore target.
+
+If something sets the setpoint to min_temp before calling turn_off, the old
+code recorded min_temp as "the value to restore" — so turn_on would write
+min_temp right back, the room would compute as still off, and it could never
+be turned back on via hvac_mode.
+"""
+
+from tests.helpers import make_state_proxy, thermostat_data
+
+THERMOSTAT = "C1_T1"
+
+
+async def test_turn_off_does_not_memorise_the_off_value(hass):
+    # Setpoint is already at min_temp (15.0) when turn_off is called.
+    data = thermostat_data(THERMOSTAT, setpoint_c=15.0, min_c=15.0, max_c=25.0)
+    proxy = make_state_proxy(hass, data=data)
+
+    await proxy.async_turn_off(THERMOSTAT)
+
+    await proxy.async_load_storage()
+    assert THERMOSTAT not in proxy._storage_data, (
+        "the off value (min_temp) must not be recorded as the restore target"
+    )
+
+
+async def test_turn_on_recovers_from_a_previously_poisoned_memo(hass):
+    # Simulate a memo poisoned by the pre-fix bug: the store already holds
+    # the off value as this room's "restore" target.
+    data = thermostat_data(THERMOSTAT, setpoint_c=15.0, min_c=15.0, max_c=25.0)
+    proxy = make_state_proxy(hass, data=data)
+    proxy._storage_data[THERMOSTAT] = 15.0
+    await proxy._store.async_save(proxy._compose_storage_payload())
+
+    await proxy.async_turn_on(THERMOSTAT)
+
+    sent_var, sent_raw = proxy._client.send_data.call_args[0][0].popitem()
+    assert sent_var == f"{THERMOSTAT}_setpoint"
+    off_raw = round(15.0 * 18 + 320)
+    default_raw = round(20.0 * 18 + 320)  # DEFAULT_TEMP fallback
+    assert sent_raw != off_raw, (
+        "turn_on restored the poisoned off-value instead of falling back to a safe default"
+    )
+    assert sent_raw == default_raw

--- a/tests/test_set_temperature_while_off.py
+++ b/tests/test_set_temperature_while_off.py
@@ -1,0 +1,48 @@
+"""Bug C: setting a temperature on an off thermostat must not be silently discarded.
+
+The old code guarded async_set_target_temperature behind `self._is_on` with
+no else branch: calling climate.set_temperature on an off room returned
+success and changed nothing, with no error and no way for the caller to
+detect it. Combined with Bug B, this is what stranded rooms off permanently
+in the field report — the follow-up set_temperature that would have rescued
+a poisoned room was silently dropped.
+"""
+
+from custom_components.uponorx265.climate import UponorClimate
+from homeassistant.const import ATTR_TEMPERATURE
+
+from tests.helpers import make_state_proxy, thermostat_data
+
+THERMOSTAT = "C1_T1"
+
+
+async def test_set_temperature_while_off_is_remembered_not_discarded(hass):
+    data = thermostat_data(THERMOSTAT, setpoint_c=19.5)
+    proxy = make_state_proxy(hass, data=data)
+
+    entity = UponorClimate("uponorx265_test", proxy, THERMOSTAT)
+    entity.hass = hass
+    entity._is_on = False  # room is currently off
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 21.0})
+
+    # Must not have written the live setpoint (that would silently turn the
+    # room back on, violating hvac_mode: off).
+    proxy._client.send_data.assert_not_called()
+
+    # The requested target must be recorded so turn_on restores it.
+    await proxy.async_load_storage()
+    assert proxy._storage_data.get(THERMOSTAT) == 21.0
+
+
+async def test_set_temperature_while_on_still_writes_the_live_setpoint(hass):
+    data = thermostat_data(THERMOSTAT, setpoint_c=19.5)
+    proxy = make_state_proxy(hass, data=data)
+
+    entity = UponorClimate("uponorx265_test", proxy, THERMOSTAT)
+    entity.hass = hass
+    entity._is_on = True
+
+    await entity.async_set_temperature(**{ATTR_TEMPERATURE: 21.0})
+
+    proxy._client.send_data.assert_called_once()

--- a/tests/test_thermostat_model_detection.py
+++ b/tests/test_thermostat_model_detection.py
@@ -1,0 +1,56 @@
+"""_detect_thermostat_model's hwid/serial-prefix heuristic, and its fallback
+to cached data when live detection isn't possible. See ARCHITECTURE.md
+"Thermostat model identification" for the (reverse-engineered, unofficial)
+rules this encodes.
+"""
+
+from tests.helpers import make_state_proxy
+
+THERMOSTAT = "C1_T1"
+ID_VAR = "C1_thermostat1_id"  # thermostat.replace('T', 'thermostat') + '_id'
+
+
+def proxy_with(hass, hwid, serial_prefix):
+    return make_state_proxy(hass, data={
+        f"{THERMOSTAT}_thermostat_type": str(hwid),
+        ID_VAR: f"{serial_prefix}00000",
+    })
+
+
+async def test_hwid_0_prefix_269_mod_1_is_t144(hass):
+    proxy = proxy_with(hass, hwid=0, serial_prefix="2691")
+    assert proxy.get_thermostat_model(THERMOSTAT) == "T-144"
+
+
+async def test_hwid_0_prefix_269_mod_2_is_t145(hass):
+    proxy = proxy_with(hass, hwid=0, serial_prefix="2692")
+    assert proxy.get_thermostat_model(THERMOSTAT) == "T-145"
+
+
+async def test_hwid_0_unknown_prefix_defaults_to_t145(hass):
+    # Field-confirmed prefix 268, not covered by the explicit 269 rule.
+    proxy = proxy_with(hass, hwid=0, serial_prefix="2688")
+    assert proxy.get_thermostat_model(THERMOSTAT) == "T-145"
+
+
+async def test_hwid_0_prefix_269_unknown_mod_defaults_to_t145(hass):
+    # 269-prefixed but neither mod "1" nor "2" — must not fall through to
+    # None, it should hit the same catch-all as any other unknown unit.
+    proxy = proxy_with(hass, hwid=0, serial_prefix="2699")
+    assert proxy.get_thermostat_model(THERMOSTAT) == "T-145"
+
+
+async def test_hwid_2_is_t146(hass):
+    proxy = proxy_with(hass, hwid=2, serial_prefix="2856")
+    assert proxy.get_thermostat_model(THERMOSTAT) == "T-146"
+
+
+async def test_missing_thermostat_type_falls_back_to_cached_model(hass):
+    proxy = make_state_proxy(hass, data={})  # no *_thermostat_type at all
+    proxy._storage_metadata = {"models": {THERMOSTAT: "T-165"}}
+    assert proxy.get_thermostat_model(THERMOSTAT) == "T-165"
+
+
+async def test_missing_thermostat_type_and_no_cache_is_none(hass):
+    proxy = make_state_proxy(hass, data={})
+    assert proxy.get_thermostat_model(THERMOSTAT) is None

--- a/tests/test_turn_off_storage_race.py
+++ b/tests/test_turn_off_storage_race.py
@@ -20,6 +20,21 @@ async def test_concurrent_turn_off_keeps_every_thermostats_memo(hass):
         data.update(thermostat_data(t, setpoint_c=19.5))
     proxy = make_state_proxy(hass, data=data)
 
+    # The test harness's mocked Store.async_save never actually suspends (no
+    # executor read, no disk write), so without a forced yield point the six
+    # turn_off coroutines below would just run to completion one after
+    # another even with no lock at all — passing regardless of the fix. A
+    # real Store does suspend (that's what lets them interleave in
+    # production), so inject an equivalent yield point here to make this a
+    # genuine regression test rather than an accidental pass.
+    real_save = proxy._store.async_save
+
+    async def yielding_save(payload):
+        await asyncio.sleep(0)
+        await real_save(payload)
+
+    proxy._store.async_save = yielding_save
+
     # Mirrors HA turning off several thermostats from one service call: the
     # coroutines run concurrently, not sequentially.
     await asyncio.gather(*(proxy.async_turn_off(t) for t in THERMOSTATS))

--- a/tests/test_turn_off_storage_race.py
+++ b/tests/test_turn_off_storage_race.py
@@ -1,0 +1,31 @@
+"""Bug A: concurrent async_turn_off() calls must not lose each other's storage writes.
+
+Before the fix, async_load_storage() replaced self._storage_data with a fresh
+dict on every call, and async_turn_off() did load -> mutate -> save with no
+locking. When several thermostats are turned off in the same service call,
+those coroutines interleave and each save only carries its own key ("last
+writer wins"), silently discarding every other room's memo.
+"""
+
+import asyncio
+
+from tests.helpers import make_state_proxy, thermostat_data
+
+THERMOSTATS = ["C1_T1", "C1_T2", "C1_T3", "C1_T4", "C1_T5", "C1_T6"]
+
+
+async def test_concurrent_turn_off_keeps_every_thermostats_memo(hass):
+    data = {}
+    for t in THERMOSTATS:
+        data.update(thermostat_data(t, setpoint_c=19.5))
+    proxy = make_state_proxy(hass, data=data)
+
+    # Mirrors HA turning off several thermostats from one service call: the
+    # coroutines run concurrently, not sequentially.
+    await asyncio.gather(*(proxy.async_turn_off(t) for t in THERMOSTATS))
+
+    await proxy.async_load_storage()
+    for t in THERMOSTATS:
+        assert proxy._storage_data.get(t) == 19.5, (
+            f"{t}'s setpoint memo was lost to a concurrent write from another thermostat"
+        )


### PR DESCRIPTION
## Summary

Fixes https://github.com/dave-code-ruiz/uponorX265/issues/33, "Rooms can get stuck off": four interacting bugs in the setpoint-restore path, plus a via_device ordering bug — with a follow-up fixing two more issues found during review of that same fix.

- **Storage race (lost update)**: `async_turn_off()` did an unlocked load-mutate-save against the setpoint memo, so concurrent turn-offs (e.g. turning off several rooms in one service call) silently dropped every room's memo but the last writer's. Serialised with a new `_storage_lock`, which also now covers the metadata-refresh save that could interleave with it.
- **Poisoned memo**: turning off a room already at `min_temp` (or `max_temp` in cool mode) recorded that off-value as the restore target, permanently stranding the room off on the next `turn_on`. The off value is no longer memorised, and a previously-poisoned memo now self-heals.
- **Silently discarded `set_temperature`**: setting a temperature on an off room used to return success and do nothing. It's now recorded via a new `async_remember_setpoint()` so `turn_on` restores the requested value, without turning the room back on.
- **`via_device` ordering**: thermostat/switch entities declare a `via_device` pointing at their controller, but the controller device was only ever created by an optional sensor entity that loads after `CLIMATE`/`SWITCH` (or never, if that sensor is disabled). Gateway and controller devices are now registered explicitly before platform setup.
- **Gateway device migration** generalised to find the old device structurally (the one device per config entry with no `via_device`) instead of guessing candidate id strings, so it isn't fooled by an id that drifted across restarts (e.g. DHCP reassigning the host IP while MAC resolution keeps failing).

Adds a `pytest` suite (`pytest-homeassistant-custom-component`) covering all of the above, the bypass max-2-per-controller rule, and the thermostat model detection heuristic. Also updates `ARCHITECTURE.md` with the new locking/registration behavior and a description of the test suite.

## Test plan
- [x] Full `pytest` suite passes (24 tests) — see `tests/`
- [x] Verified each regression test fails against the pre-fix code and passes against the fix (checked via temporary `git stash`/checkout of the old implementation)
- [x] Verified on real hardware: multi-room turn-off, turn-off-then-turn-on, `set_temperature` while off